### PR TITLE
Fix/kevent read event

### DIFF
--- a/src/ClientEventControllerRead.cpp
+++ b/src/ClientEventControllerRead.cpp
@@ -117,6 +117,10 @@ void ClientEventController::parseBody() {
 enum EventController::returnType ClientEventController::clientRead(
     const struct kevent &event) {
 
+  if (event.data == 0) { // closed socket
+    return SUCCESS;
+  }
+
   char recvBuff[event.data + 1];
   int tmpInt = read(event.ident, recvBuff, event.data);
   if (tmpInt == -1) {


### PR DESCRIPTION
1. EV_CLEAR 를 사용하는 과정에서 데이터를 정해진 길이만 읽고 나머지 데이터를 읽지 못해 생기는 문제를 해결했습니다.
2. event가 READ 이며 event.data == 0 인 경우 소켓이 닫힌 것으로 판단하고 이벤트를 끝내는 내용을 추가했습니다.