### PR TITLE
fix: fatal socket handling

### DIFF
--- a/src/ClientEventControllerRead.cpp
+++ b/src/ClientEventControllerRead.cpp
@@ -117,7 +117,8 @@ void ClientEventController::parseBody() {
 enum EventController::returnType ClientEventController::clientRead(
     const struct kevent &event) {
 
-  if (event.data == 0) { // closed socket
+  if (event.flags & EV_EOF) { // closed socket
+    close(clientSocket_);
     return SUCCESS;
   }
 

--- a/src/ClientEventControllerWrite.cpp
+++ b/src/ClientEventControllerWrite.cpp
@@ -130,5 +130,5 @@ enum EventController::returnType ClientEventController::clientWrite(const struct
   write(event.ident, "\r\n", 2);
   write(event.ident, "hello\n", 6);
   evSet(EVFILT_WRITE, EV_DELETE); // write 이벤트를 안 받는다
-  return SUCCESS;
+  return PENDING;
 }

--- a/src/ServerEventController.cpp
+++ b/src/ServerEventController.cpp
@@ -58,7 +58,8 @@ enum EventController::returnType ServerEventController::handleEvent(const struct
   std::cout << "---------- client accept" << std::endl;
   int clientSocket = accept(event.ident, (struct sockaddr*)&client_addr, &client_addr_size);
   if (clientSocket == -1) {
-    return FAIL;
+    std::cout << "accept error" << std::endl;
+    return PENDING;
   }
   struct kevent clientEvent;
   struct timespec timeout = {10, 0}; // 10 seconds


### PR DESCRIPTION
소켓에 관련한 다양한 에러에 대비하기 위해 다음 세 가지 내용을 수정합니다.

---
1. 잘못된 EOF 확인
클라이언트가 먼저 소켓을 끊었을때 `event.data` 가 0 이 될 것이라 추측하고 예전과 같은 코드를 작성했지만 실제는 그렇지 않고 `event.flags` 에 `EV_EOF` 가 세팅된 것을 확인하고 다음과 같이 수정합니다. 또한 정상적으로 소켓을 닫아 여러 에러를 방지합니다.
https://github.com/42seoulWebserv/irc/blob/33450dd53f5dabbb0d5cbf6911fda3de3caa9f61/src/ClientEventControllerRead.cpp#L120-L123

2. Write return 방식 변경
클라이언트에게 모든 `response`를 제공했더라도 성급하게 `SUCCESS` 처리해서는 안됩니다. `SUCCESS` 처리하려면 해당 소켓을 사용하는 컨트롤러를 `kevent`에 새로 추가해주거나 `close` 하여 소켓을 정상적으로 닫아 여러 에러를 방지합니다.

3. 불멸의 서버
서버는 어떠한 경우에도 죽지 않아야 합니다. `FAIL` 대신 에러 메시지를 출력하고 `PENDING` 으로 처리하여 서버를 지속시켰습니다.
https://github.com/42seoulWebserv/irc/blob/33450dd53f5dabbb0d5cbf6911fda3de3caa9f61/src/ServerEventController.cpp#L60-L63
