### PR TITLE
fix: :bug: location path mush be in absolute path form

### DIFF
--- a/src/config/configChecker/ConfigChecker.cpp
+++ b/src/config/configChecker/ConfigChecker.cpp
@@ -132,13 +132,15 @@ static void checkServerName(std::string str) {
 
 static void checkServerLocationDuplicate(std::string locationUri,
                                          std::set<std::string> &locationPaths) {
-  if (locationUri.at(0) != '/') {
-    throw std::invalid_argument("location path must be in absolute path form");
+  if (locationUri.at(0) != '/' || locationUri.back() != '/') {
+    throw std::invalid_argument('"' + locationUri + '"' +
+                                " location path must be in absolute path form");
   }
   if (locationPaths.find(locationUri) == locationPaths.end()) {
     locationPaths.insert(locationUri);
   } else {
-    throw std::invalid_argument("location path cannot be duplicated");
+    throw std::invalid_argument('"' + locationUri + '"' +
+                                " location path cannot be duplicated");
   }
 }
 


### PR DESCRIPTION
default.conf에서 `location`의 경로가 상대 경로일 경우 `exception`을 던지는 코드로 변경하였습니다.