### PR TITLE
Fix/file io

### DIFF
--- a/src/FileReadEventController.cpp
+++ b/src/FileReadEventController.cpp
@@ -2,17 +2,31 @@
 
 #include <fcntl.h>
 #include <sys/event.h>  // kevent
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <exception>
+#include <fstream>
 
 FileReadEventController::FileReadEventController(int kq,
                                                  const std::string &filepath,
                                                  IObserver<Event> *observer)
     : kq_(kq), filepath_(filepath), observer_(observer) {
-  fd_ = open(filepath_.c_str(), O_RDONLY);
+  const char *file = filepath.c_str();
+  struct stat statbuf;
+  if (stat(file, &statbuf)) {
+    throw FileReadException(FileReadEventController::NOT_FOUND);
+  }
+  if (access(file, R_OK)) {
+    throw FileReadException(FileReadEventController::NOT_ACCESS);
+  }
+  if (statbuf.st_size == 0) {
+    throw FileReadException(FileReadEventController::SUCCESS);
+  }
+  fd_ = open(file, O_RDONLY);
   if (fd_ == -1) {
-    throw std::invalid_argument("file open error");
+    throw FileReadException(FileReadEventController::FAIL);
   }
   fcntl(fd_, F_SETFL, O_NONBLOCK);
   fcntl(fd_, F_SETFD, FD_CLOEXEC);
@@ -26,10 +40,13 @@ void FileReadEventController::addEventController(int kq_,
                                                  IObserver<Event> *observer) {
   try {
     new FileReadEventController(kq_, filepath, observer);
-  } catch (...) {
-    if (observer) {
-      observer->onEvent(Event(FileReadEventController::FAIL, ""));
+  } catch (const FileReadException &e) {
+    if (observer == NULL) {
+      return;
     }
+    observer->onEvent(Event(e.type_, ""));
+  } catch (...) {
+    observer->onEvent(Event(FileReadEventController::FAIL, ""));
   }
 }
 
@@ -60,3 +77,6 @@ EventController::returnType FileReadEventController::handleEvent(
 FileReadEventController::Event::Event(EventType type,
                                       const std::string &content)
     : type_(type), content_(content) {}
+
+FileReadEventController::FileReadException::FileReadException(EventType type)
+    : type_(type) {}

--- a/src/FileReadEventController.hpp
+++ b/src/FileReadEventController.hpp
@@ -3,17 +3,24 @@
 
 #define FILE_READ_BUFF_SIZE 16384
 
+#include <exception>
+
 #include "EventController.hpp"
 #include "IObserver.hpp"
 
 class FileReadEventController : public EventController {
  public:
-  enum EventType { SUCCESS, FAIL };
+  enum EventType { SUCCESS, FAIL, NOT_FOUND, NOT_ACCESS };
   class Event {
    public:
     Event(enum EventType type, const std::string &content);
     enum EventType type_;
     const std::string &content_;
+  };
+  class FileReadException : public std::exception {
+   public:
+    FileReadException(EventType type);
+    enum EventType type_;
   };
   static void addEventController(int kq_, const std::string &filepath,
                                  IObserver<Event> *observer);

--- a/src/FileWriteEventController.hpp
+++ b/src/FileWriteEventController.hpp
@@ -8,13 +8,17 @@
 
 class FileWriteEventController : public EventController {
  public:
-  enum EventType { SUCCESS, FAIL };
+  enum EventType { SUCCESS, FAIL, NOT_ACCESS };
   class Event {
    public:
     Event(enum EventType type);
     enum EventType type_;
   };
-
+  class FileWriteException : public std::exception {
+   public:
+    FileWriteException(EventType type);
+    enum EventType type_;
+  };
   static void addEventController(int kq, const std::string &filepath,
                                  const std::string &content,
                                  IObserver<Event> *observer);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,9 +10,37 @@
 
 #include "ConfigLexer.hpp"
 #include "ConfigMaker.hpp"
+#include "FileReadEventController.hpp"
+#include "FileWriteEventController.hpp"
+#include "IObserver.hpp"
 #include "RootConfig.hpp"
 #include "ServerConfig.hpp"
 #include "ServerEventController.hpp"
+
+class TestObserver : public IObserver<FileReadEventController::Event>,
+                     public IObserver<FileWriteEventController::Event> {
+  void onEvent(const FileReadEventController::Event &event) {
+    if (event.type_ == FileReadEventController::SUCCESS)
+      std::cout << "SUCCESS" << std::endl;
+    if (event.type_ == FileReadEventController::NOT_ACCESS)
+      std::cout << "NOT_ACCESS" << std::endl;
+    if (event.type_ == FileReadEventController::FAIL)
+      std::cout << "FAIL" << std::endl;
+    if (event.type_ == FileReadEventController::NOT_FOUND)
+      std::cout << "NOT_FOUND" << std::endl;
+    std::cout << event.content_ << std::endl;
+    std::cout << " --- read --- " << std::endl;
+  }
+  void onEvent(const FileWriteEventController::Event &event) {
+    if (event.type_ == FileWriteEventController::SUCCESS)
+      std::cout << "SUCCESS" << std::endl;
+    if (event.type_ == FileWriteEventController::NOT_ACCESS)
+      std::cout << "NOT_ACCESS" << std::endl;
+    if (event.type_ == FileWriteEventController::FAIL)
+      std::cout << "FAIL" << std::endl;
+    std::cout << " --- write --- " << std::endl;
+  }
+};
 
 int run(RootConfig &config) {
   int kq = kqueue();
@@ -40,6 +68,10 @@ int run(RootConfig &config) {
       }
     }
   }
+
+  TestObserver ob;
+  // FileReadEventController::addEventController(kq, "Makefile", &ob);
+  // FileWriteEventController::addEventController(kq, "new", "message", &ob);
 
   while (1) {
     struct kevent eventList[5];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,37 +10,9 @@
 
 #include "ConfigLexer.hpp"
 #include "ConfigMaker.hpp"
-#include "FileReadEventController.hpp"
-#include "FileWriteEventController.hpp"
-#include "IObserver.hpp"
 #include "RootConfig.hpp"
 #include "ServerConfig.hpp"
 #include "ServerEventController.hpp"
-
-class TestObserver : public IObserver<FileReadEventController::Event>,
-                     public IObserver<FileWriteEventController::Event> {
-  void onEvent(const FileReadEventController::Event &event) {
-    if (event.type_ == FileReadEventController::SUCCESS)
-      std::cout << "SUCCESS" << std::endl;
-    if (event.type_ == FileReadEventController::NOT_ACCESS)
-      std::cout << "NOT_ACCESS" << std::endl;
-    if (event.type_ == FileReadEventController::FAIL)
-      std::cout << "FAIL" << std::endl;
-    if (event.type_ == FileReadEventController::NOT_FOUND)
-      std::cout << "NOT_FOUND" << std::endl;
-    std::cout << event.content_ << std::endl;
-    std::cout << " --- read --- " << std::endl;
-  }
-  void onEvent(const FileWriteEventController::Event &event) {
-    if (event.type_ == FileWriteEventController::SUCCESS)
-      std::cout << "SUCCESS" << std::endl;
-    if (event.type_ == FileWriteEventController::NOT_ACCESS)
-      std::cout << "NOT_ACCESS" << std::endl;
-    if (event.type_ == FileWriteEventController::FAIL)
-      std::cout << "FAIL" << std::endl;
-    std::cout << " --- write --- " << std::endl;
-  }
-};
 
 int run(RootConfig &config) {
   int kq = kqueue();
@@ -68,10 +40,6 @@ int run(RootConfig &config) {
       }
     }
   }
-
-  TestObserver ob;
-  // FileReadEventController::addEventController(kq, "Makefile", &ob);
-  // FileWriteEventController::addEventController(kq, "new", "message", &ob);
 
   while (1) {
     struct kevent eventList[5];


### PR DESCRIPTION
- 파일을 읽는 과정에서 다음과 같은 에러 처리를 추가했습니다.
  - 파일을 찾을 수 없음 `NOT_FOUND`
  - 파일을 읽을 권한이 없음 `NOT_ACCESS`
- 파일을 쓰는 과정에서 다음과 같은 에러 처리를 추가했습니다.
  - 파일이 이미 존재하고 해당 파일에 쓰기 권한이 없음 `NOT_ACCESS`

다음 커밋을 `checkout`하여 테스트 해보실 수 있습니다.
- d1a2c17dc370f80f4c1b0f87008a487e99add709

---
파일의 읽기 쓰기 작업을 수정하다가 다음 문제를 확인하였으며 이 내용은 추후에 다룹니다.
- #19