### PR TITLE
feat: add filepath util (#21)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INC_DIR := \
 	-I./src/config/configLexer \
 	-I./src/config/configMaker \
 	-I./src/processor \
+	-I./src/util \
 
 SRC_DIR := ./src
 BUILD_DIR := ./build
@@ -72,6 +73,10 @@ PROCESSOR_NAME := \
 	MethodPutProcessor.cpp \
 	UnsupportedMethodProcessor.cpp \
 
+UTIL_DIR := ./src/util/
+UTIL_NAME := \
+	FilePath.cpp \
+
 SRCS := \
 	$(addprefix $(MAIN_DIR), $(MAIN_NAME)) \
 	$(addprefix $(CONFIG_DIR), $(CONFIG_NAME)) \
@@ -80,6 +85,7 @@ SRCS := \
 	$(addprefix $(CONFIGMAKER_DIR), $(CONFIGMAKER_NAME)) \
 	$(addprefix $(PASER_LEXER_DIR), $(PASER_LEXER_NAME)) \
 	$(addprefix $(PROCESSOR_DIR), $(PROCESSOR_NAME)) \
+	$(addprefix $(UTIL_DIR), $(UTIL_NAME)) \
 
 SRCS_DIR := \
 	$(MAIN_DIR) \
@@ -89,6 +95,7 @@ SRCS_DIR := \
 	$(CONFIGMAKER_DIR) \
 	$(PASER_LEXER_DIR) \
 	$(PROCESSOR_DIR) \
+	$(UTIL_DIR) \
 
 vpath %.cpp $(SRCS_DIR)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <sys/event.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -11,93 +10,9 @@
 
 #include "ConfigLexer.hpp"
 #include "ConfigMaker.hpp"
-#include "FilePath.hpp"
 #include "RootConfig.hpp"
 #include "ServerConfig.hpp"
 #include "ServerEventController.hpp"
-
-void testFilePath() {
-  {  // constructor test
-    FilePath root("/");
-    assert(root.getPath() == "/");
-    root.appendPath("test");
-    assert(root.getPath() == "/test");
-
-    FilePath current2("");
-    assert(current2.getPath() == "");
-    current2.appendPath("test");
-    assert(current2.getPath() == "test");
-  }
-  {  // appendPath test
-    FilePath path("/test1");
-    assert(path.getPath() == "/test1");
-    path.appendPath("test2");
-    assert(path.getPath() == "/test1/test2");
-    path.appendPath("test3");
-    assert(path.getPath() == "/test1/test2/test3");
-    path.appendPath("/test4");
-    assert(path.getPath() == "/test1/test2/test3/test4");
-    path.appendPath("/test5/");
-    assert(path.getPath() == "/test1/test2/test3/test4/test5/");
-  }
-  {  // isExist test
-    FilePath makefile("Makefile");
-    assert(makefile.isExist());
-
-    FilePath longFilePath("we-are-project-name-is-irc-but-it-is-not-irc");
-    assert(!longFilePath.isExist());
-  }
-  {  // isDirectory, isFile test
-    FilePath srcDir("src");
-    assert(srcDir.isDirectory());
-    assert(!srcDir.isFile());
-
-    FilePath srcDirWithSlash("src/");
-    assert(srcDirWithSlash.isDirectory());
-    assert(!srcDir.isFile());
-
-    FilePath makefile("Makefile");
-    assert(!makefile.isDirectory());
-    assert(makefile.isFile());
-
-    FilePath makefileWithSlash("Makefile/");
-    assert(!makefileWithSlash.isDirectory());
-    assert(!makefileWithSlash.isFile());
-  }
-  {  // toDirectoryPath, toFilePath test
-    FilePath path2("src");
-    assert(path2.toFilePath() == "src");
-    assert(path2.toDirectoryPath() == "src/");
-
-    FilePath path1("src/");
-    assert(path1.toFilePath() == "src");
-    assert(path1.toDirectoryPath() == "src/");
-
-    FilePath longPath1("is/not/irc/");
-    assert(longPath1.toFilePath() == "is/not/irc");
-    assert(longPath1.toDirectoryPath() == "is/not/irc/");
-
-    FilePath longPath2("is/not/irc");
-    assert(longPath2.toFilePath() == "is/not/irc");
-    assert(longPath2.toDirectoryPath() == "is/not/irc/");
-  }
-  {  // getExtension, getFileName, getDirectory test
-    FilePath path1("src/main.cpp");
-    assert(FilePath::getExtension(path1) == "cpp");
-    assert(FilePath::getFileName(path1) == "main.cpp");
-    assert(FilePath::getDirectory(path1) == "src");
-
-    FilePath path2("src/");
-    assert(FilePath::getExtension(path2) == "");
-    assert(FilePath::getFileName(path2) == "");
-    assert(FilePath::getDirectory(path2) == "src");
-
-    FilePath path3("src");
-    assert(FilePath::getExtension(path3) == "");
-    assert(FilePath::getFileName(path3) == "src");
-    assert(FilePath::getDirectory(path3) == "");
-  }
-}
 
 int run(RootConfig &config) {
   int kq = kqueue();
@@ -170,10 +85,8 @@ int main(int argc, char **argv) {
 
   Directive directive = ConfigLexer::run(configStr);
   RootConfig config = ConfigMaker::makeConfig(directive);
-  // config.printRootConfig();
+  config.printRootConfig();
 
-  // run(config);
-  testFilePath();
-
+  run(config);
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <sys/event.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -10,9 +11,93 @@
 
 #include "ConfigLexer.hpp"
 #include "ConfigMaker.hpp"
+#include "FilePath.hpp"
 #include "RootConfig.hpp"
 #include "ServerConfig.hpp"
 #include "ServerEventController.hpp"
+
+void testFilePath() {
+  {  // constructor test
+    FilePath root("/");
+    assert(root.getPath() == "/");
+    root.appendPath("test");
+    assert(root.getPath() == "/test");
+
+    FilePath current2("");
+    assert(current2.getPath() == "");
+    current2.appendPath("test");
+    assert(current2.getPath() == "test");
+  }
+  {  // appendPath test
+    FilePath path("/test1");
+    assert(path.getPath() == "/test1");
+    path.appendPath("test2");
+    assert(path.getPath() == "/test1/test2");
+    path.appendPath("test3");
+    assert(path.getPath() == "/test1/test2/test3");
+    path.appendPath("/test4");
+    assert(path.getPath() == "/test1/test2/test3/test4");
+    path.appendPath("/test5/");
+    assert(path.getPath() == "/test1/test2/test3/test4/test5/");
+  }
+  {  // isExist test
+    FilePath makefile("Makefile");
+    assert(makefile.isExist());
+
+    FilePath longFilePath("we-are-project-name-is-irc-but-it-is-not-irc");
+    assert(!longFilePath.isExist());
+  }
+  {  // isDirectory, isFile test
+    FilePath srcDir("src");
+    assert(srcDir.isDirectory());
+    assert(!srcDir.isFile());
+
+    FilePath srcDirWithSlash("src/");
+    assert(srcDirWithSlash.isDirectory());
+    assert(!srcDir.isFile());
+
+    FilePath makefile("Makefile");
+    assert(!makefile.isDirectory());
+    assert(makefile.isFile());
+
+    FilePath makefileWithSlash("Makefile/");
+    assert(!makefileWithSlash.isDirectory());
+    assert(!makefileWithSlash.isFile());
+  }
+  {  // toDirectoryPath, toFilePath test
+    FilePath path2("src");
+    assert(path2.toFilePath() == "src");
+    assert(path2.toDirectoryPath() == "src/");
+
+    FilePath path1("src/");
+    assert(path1.toFilePath() == "src");
+    assert(path1.toDirectoryPath() == "src/");
+
+    FilePath longPath1("is/not/irc/");
+    assert(longPath1.toFilePath() == "is/not/irc");
+    assert(longPath1.toDirectoryPath() == "is/not/irc/");
+
+    FilePath longPath2("is/not/irc");
+    assert(longPath2.toFilePath() == "is/not/irc");
+    assert(longPath2.toDirectoryPath() == "is/not/irc/");
+  }
+  {  // getExtension, getFileName, getDirectory test
+    FilePath path1("src/main.cpp");
+    assert(FilePath::getExtension(path1) == "cpp");
+    assert(FilePath::getFileName(path1) == "main.cpp");
+    assert(FilePath::getDirectory(path1) == "src");
+
+    FilePath path2("src/");
+    assert(FilePath::getExtension(path2) == "");
+    assert(FilePath::getFileName(path2) == "");
+    assert(FilePath::getDirectory(path2) == "src");
+
+    FilePath path3("src");
+    assert(FilePath::getExtension(path3) == "");
+    assert(FilePath::getFileName(path3) == "src");
+    assert(FilePath::getDirectory(path3) == "");
+  }
+}
 
 int run(RootConfig &config) {
   int kq = kqueue();
@@ -85,8 +170,10 @@ int main(int argc, char **argv) {
 
   Directive directive = ConfigLexer::run(configStr);
   RootConfig config = ConfigMaker::makeConfig(directive);
-  config.printRootConfig();
+  // config.printRootConfig();
 
-  run(config);
+  // run(config);
+  testFilePath();
+
   return 0;
 }

--- a/src/util/FilePath.cpp
+++ b/src/util/FilePath.cpp
@@ -8,24 +8,24 @@ FilePath::FilePath() {}
 
 FilePath::FilePath(const std::string& path) { setPath(path); }
 
-void FilePath::setPath(const std::string& path) { this->path_ = path; }
+void FilePath::setPath(const std::string& path) { assign(path); }
 
-const std::string& FilePath::getPath() const { return path_; }
+const std::string& FilePath::getPath() const { return *this; }
 
 void FilePath::appendPath(const std::string& path) {
-  if (path_.size() > 0 && path_.back() != '/') {
-    path_.push_back('/');
+  if (size() > 0 && back() != '/') {
+    push_back('/');
   }
   if (path.size() > 0 && path[0] == '/') {
-    path_.append(path.substr(1));
+    append(path.substr(1));
     return;
   }
-  path_.append(path);
+  append(path);
 }
 
 bool FilePath::isExist() const {
   struct stat stat_;
-  if (stat(path_.c_str(), &stat_)) {
+  if (stat(c_str(), &stat_)) {
     return false;
   }
   return true;
@@ -33,7 +33,7 @@ bool FilePath::isExist() const {
 
 bool FilePath::isDirectory() const {
   struct stat stat_;
-  if (stat(path_.c_str(), &stat_)) {
+  if (stat(c_str(), &stat_)) {
     return false;
   }
   return S_ISDIR(stat_.st_mode);
@@ -41,7 +41,7 @@ bool FilePath::isDirectory() const {
 
 bool FilePath::isFile() const {
   struct stat stat_;
-  if (stat(path_.c_str(), &stat_)) {
+  if (stat(c_str(), &stat_)) {
     return false;
   }
   return S_ISREG(stat_.st_mode);
@@ -49,19 +49,15 @@ bool FilePath::isFile() const {
 
 bool FilePath::isAccessible(accessType type) const {
   if (type == READ) {
-    return access(path_.c_str(), R_OK) == 0;
+    return access(c_str(), R_OK) == 0;
   }
   if (type == WRITE) {
-    return access(path_.c_str(), W_OK) == 0;
+    return access(c_str(), W_OK) == 0;
   }
   if (type == EXECUTE) {
-    return access(path_.c_str(), X_OK) == 0;
+    return access(c_str(), X_OK) == 0;
   }
   return false;
-}
-
-std::string FilePath::getExtension(const FilePath& path) {
-  return getExtension(path.getPath());
 }
 
 std::string FilePath::getExtension(const std::string& path) {
@@ -73,21 +69,17 @@ std::string FilePath::getExtension(const std::string& path) {
 }
 
 std::string FilePath::toDirectoryPath() {
-  if (path_.back() != '/') {
-    return path_ + '/';
+  if (back() != '/') {
+    return *this + '/';
   }
-  return path_;
+  return *this;
 }
 
 std::string FilePath::toFilePath() {
-  if (path_.back() == '/') {
-    return path_.substr(0, path_.size() - 1);
+  if (back() == '/') {
+    return substr(0, size() - 1);
   }
-  return path_;
-}
-
-std::string FilePath::getFileName(const FilePath& path) {
-  return getFileName(path.getPath());
+  return *this;
 }
 
 std::string FilePath::getFileName(const std::string& path) {
@@ -96,10 +88,6 @@ std::string FilePath::getFileName(const std::string& path) {
     return path;
   }
   return path.substr(pos + 1);
-}
-
-std::string FilePath::getDirectory(const FilePath& path) {
-  return getDirectory(path.getPath());
 }
 
 std::string FilePath::getDirectory(const std::string& path) {

--- a/src/util/FilePath.cpp
+++ b/src/util/FilePath.cpp
@@ -1,0 +1,116 @@
+#include "FilePath.hpp"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+FilePath::FilePath() {}
+
+FilePath::FilePath(const std::string& path) { setPath(path); }
+
+void FilePath::setPath(const std::string& path) { this->path_ = path; }
+
+const std::string& FilePath::getPath() const { return path_; }
+
+void FilePath::appendPath(const std::string& path) {
+  if (path_.size() > 0 && path_.back() != '/') {
+    path_.push_back('/');
+  }
+  if (path.size() > 0 && path[0] == '/') {
+    path_.append(path.substr(1));
+    return;
+  }
+  path_.append(path);
+}
+
+bool FilePath::isExist() const {
+  struct stat stat_;
+  if (stat(path_.c_str(), &stat_)) {
+    return false;
+  }
+  return true;
+}
+
+bool FilePath::isDirectory() const {
+  struct stat stat_;
+  if (stat(path_.c_str(), &stat_)) {
+    return false;
+  }
+  return S_ISDIR(stat_.st_mode);
+}
+
+bool FilePath::isFile() const {
+  struct stat stat_;
+  if (stat(path_.c_str(), &stat_)) {
+    return false;
+  }
+  return S_ISREG(stat_.st_mode);
+}
+
+bool FilePath::isAccessible(accessType type) const {
+  if (type == READ) {
+    return access(path_.c_str(), R_OK) == 0;
+  }
+  if (type == WRITE) {
+    return access(path_.c_str(), W_OK) == 0;
+  }
+  if (type == EXECUTE) {
+    return access(path_.c_str(), X_OK) == 0;
+  }
+  return false;
+}
+
+std::string FilePath::getExtension(const FilePath& path) {
+  return getExtension(path.getPath());
+}
+
+std::string FilePath::getExtension(const std::string& path) {
+  size_t pos = path.rfind('.');
+  if (pos == std::string::npos) {
+    return "";
+  }
+  return path.substr(pos + 1);
+}
+
+std::string FilePath::toDirectoryPath() {
+  if (path_.back() != '/') {
+    return path_ + '/';
+  }
+  return path_;
+}
+
+std::string FilePath::toFilePath() {
+  if (path_.back() == '/') {
+    return path_.substr(0, path_.size() - 1);
+  }
+  return path_;
+}
+
+std::string FilePath::getFileName(const FilePath& path) {
+  return getFileName(path.getPath());
+}
+
+std::string FilePath::getFileName(const std::string& path) {
+  size_t pos = path.rfind('/');
+  if (pos == std::string::npos) {
+    return path;
+  }
+  return path.substr(pos + 1);
+}
+
+std::string FilePath::getDirectory(const FilePath& path) {
+  return getDirectory(path.getPath());
+}
+
+std::string FilePath::getDirectory(const std::string& path) {
+  size_t pos = path.rfind('/');
+  if (pos == std::string::npos) {
+    return "";
+  }
+  return path.substr(0, pos);
+}
+
+std::ostream& operator<<(std::ostream& os, const FilePath& path) {
+  os << path.getPath();
+  return os;
+}

--- a/src/util/FilePath.cpp
+++ b/src/util/FilePath.cpp
@@ -24,27 +24,27 @@ void FilePath::appendPath(const std::string& path) {
 }
 
 bool FilePath::isExist() const {
-  struct stat stat_;
-  if (stat(c_str(), &stat_)) {
+  struct stat statData;
+  if (stat(c_str(), &statData)) {
     return false;
   }
   return true;
 }
 
 bool FilePath::isDirectory() const {
-  struct stat stat_;
-  if (stat(c_str(), &stat_)) {
+  struct stat statData;
+  if (stat(c_str(), &statData)) {
     return false;
   }
-  return S_ISDIR(stat_.st_mode);
+  return S_ISDIR(statData.st_mode);
 }
 
 bool FilePath::isFile() const {
-  struct stat stat_;
-  if (stat(c_str(), &stat_)) {
+  struct stat statData;
+  if (stat(c_str(), &statData)) {
     return false;
   }
-  return S_ISREG(stat_.st_mode);
+  return S_ISREG(statData.st_mode);
 }
 
 bool FilePath::isAccessible(accessType type) const {
@@ -58,6 +58,14 @@ bool FilePath::isAccessible(accessType type) const {
     return access(c_str(), X_OK) == 0;
   }
   return false;
+}
+
+long FilePath::getFileSize() const {
+  struct stat statData;
+  if (stat(c_str(), &statData)) {
+    return -1;
+  }
+  return statData.st_size;
 }
 
 std::string FilePath::getExtension(const std::string& path) {

--- a/src/util/FilePath.hpp
+++ b/src/util/FilePath.hpp
@@ -1,0 +1,36 @@
+#ifndef FilePath_HPP_
+#define FilePath_HPP_
+
+#include <iostream>
+
+class FilePath {
+ public:
+  FilePath();
+  FilePath(const std::string &path);
+
+  enum accessType { READ, WRITE, EXECUTE };
+
+  void setPath(const std::string &path);
+  const std::string &getPath() const;
+  void appendPath(const std::string &path);
+  bool isExist() const;
+  bool isDirectory() const;
+  bool isFile() const;
+  bool isAccessible(enum accessType type) const;
+  std::string toDirectoryPath();
+  std::string toFilePath();
+
+  static std::string getExtension(const FilePath &path);
+  static std::string getExtension(const std::string &path);
+  static std::string getFileName(const FilePath &path);
+  static std::string getFileName(const std::string &path);
+  static std::string getDirectory(const FilePath &path);
+  static std::string getDirectory(const std::string &path);
+
+ private:
+  std::string path_;
+};
+
+std::ostream &operator<<(std::ostream &os, const FilePath &path);
+
+#endif

--- a/src/util/FilePath.hpp
+++ b/src/util/FilePath.hpp
@@ -17,6 +17,7 @@ class FilePath : public std::string {
   bool isDirectory() const;
   bool isFile() const;
   bool isAccessible(enum accessType type) const;
+  long getFileSize() const;
   std::string toDirectoryPath();
   std::string toFilePath();
 

--- a/src/util/FilePath.hpp
+++ b/src/util/FilePath.hpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-class FilePath {
+class FilePath : public std::string {
  public:
   FilePath();
   FilePath(const std::string &path);
@@ -20,17 +20,9 @@ class FilePath {
   std::string toDirectoryPath();
   std::string toFilePath();
 
-  static std::string getExtension(const FilePath &path);
   static std::string getExtension(const std::string &path);
-  static std::string getFileName(const FilePath &path);
   static std::string getFileName(const std::string &path);
-  static std::string getDirectory(const FilePath &path);
   static std::string getDirectory(const std::string &path);
-
- private:
-  std::string path_;
 };
-
-std::ostream &operator<<(std::ostream &os, const FilePath &path);
 
 #endif


### PR DESCRIPTION
파일을 읽기 위해 경로를 계산하는 공통 모듈을 만들었습니다 : `FilePath`
- issue #21 

파일 경로 문자열에 다른 파일 경로 문자열을 붙일때 `/`문자가 두 번 들어가거나 들어가지 않는 문제를 해결하고자 만들었으며
이 클래스는 다음과 같은 추가 기능을 갖습니다.
- 실제 파일/디렉토리가 있는지 검사
- 실제 파일/디렉토리에 접근 가능한지 검사
- 실제 파일의 크기 검사
- 문자열에서 디렉토리 이름 찾기
- 문자열에서 파일 이름 찾기
- 문자열에서 확장자 찾기

다음 커밋을 `checkout`하여 테스트 해보실 수 있습니다.
- 656ed4a0edcd4b0b1bd6312e5598d8fc19e929da

귀찮으면 아래 코드 내용을 보고 사용 방법과 처리 방식을 확인하실 수 있습니다.
<details>
<summary>Test Code</summary>

```c++
#include <assert.h>
#include "FilePath.hpp"
void testFilePath() {
  {  // constructor test
    FilePath root("/");
    assert(root.getPath() == "/");
    root.appendPath("test");
    assert(root.getPath() == "/test");

    FilePath current2("");
    assert(current2.getPath() == "");
    current2.appendPath("test");
    assert(current2.getPath() == "test");
  }
  {  // appendPath test
    FilePath path("/test1");
    assert(path.getPath() == "/test1");
    path.appendPath("test2");
    assert(path.getPath() == "/test1/test2");
    path.appendPath("test3");
    assert(path.getPath() == "/test1/test2/test3");
    path.appendPath("/test4");
    assert(path.getPath() == "/test1/test2/test3/test4");
    path.appendPath("/test5/");
    assert(path.getPath() == "/test1/test2/test3/test4/test5/");
  }
  {  // isExist test
    FilePath makefile("Makefile");
    assert(makefile.isExist());

    FilePath longFilePath("we-are-project-name-is-irc-but-it-is-not-irc");
    assert(!longFilePath.isExist());
  }
  {  // isDirectory, isFile test
    FilePath srcDir("src");
    assert(srcDir.isDirectory());
    assert(!srcDir.isFile());

    FilePath srcDirWithSlash("src/");
    assert(srcDirWithSlash.isDirectory());
    assert(!srcDir.isFile());

    FilePath makefile("Makefile");
    assert(!makefile.isDirectory());
    assert(makefile.isFile());

    FilePath makefileWithSlash("Makefile/");
    assert(!makefileWithSlash.isDirectory());
    assert(!makefileWithSlash.isFile());
  }
  {  // toDirectoryPath, toFilePath test
    FilePath path2("src");
    assert(path2.toFilePath() == "src");
    assert(path2.toDirectoryPath() == "src/");

    FilePath path1("src/");
    assert(path1.toFilePath() == "src");
    assert(path1.toDirectoryPath() == "src/");

    FilePath longPath1("is/not/irc/");
    assert(longPath1.toFilePath() == "is/not/irc");
    assert(longPath1.toDirectoryPath() == "is/not/irc/");

    FilePath longPath2("is/not/irc");
    assert(longPath2.toFilePath() == "is/not/irc");
    assert(longPath2.toDirectoryPath() == "is/not/irc/");
  }
  {  // getExtension, getFileName, getDirectory test
    FilePath path1("src/main.cpp");
    assert(FilePath::getExtension(path1) == "cpp");
    assert(FilePath::getFileName(path1) == "main.cpp");
    assert(FilePath::getDirectory(path1) == "src");

    FilePath path2("src/");
    assert(FilePath::getExtension(path2) == "");
    assert(FilePath::getFileName(path2) == "");
    assert(FilePath::getDirectory(path2) == "src");

    FilePath path3("src");
    assert(FilePath::getExtension(path3) == "");
    assert(FilePath::getFileName(path3) == "src");
    assert(FilePath::getDirectory(path3) == "");
  }
}
```
</details>

더 좋은 개선 방안이나 질문은 언제든 받습니다. 코멘트로 남겨주세요