### PR TITLE
Feat/select processor

### DIFF
--- a/src/ClientEventController.cpp
+++ b/src/ClientEventController.cpp
@@ -12,6 +12,7 @@ ClientEventController::ClientEventController(int kq, int clientSocket)
       kq_(kq),
       statusCode_(0),
       clientSocket_(clientSocket),
+      config_(NULL),
       processor_(NULL) {}
 
 ClientEventController::ClientEventController(const ClientEventController &src)
@@ -19,6 +20,7 @@ ClientEventController::ClientEventController(const ClientEventController &src)
       kq_(src.kq_),
       statusCode_(src.statusCode_),
       clientSocket_(src.clientSocket_),
+      config_(NULL),
       processor_(NULL) {}
 
 ClientEventController &ClientEventController::operator=(
@@ -27,6 +29,7 @@ ClientEventController &ClientEventController::operator=(
   this->statusCode_ = rhs.statusCode_;
   this->readStatus_ = rhs.readStatus_;
   this->clientSocket_ = rhs.clientSocket_;
+  this->config_ = rhs.config_;
   return *this;
 }
 

--- a/src/processor/RequestProcessorFactory.cpp
+++ b/src/processor/RequestProcessorFactory.cpp
@@ -1,9 +1,30 @@
 #include "RequestProcessorFactory.hpp"
 
+#include "MethodDeleteProcessor.hpp"
 #include "MethodGetProcessor.hpp"
+#include "MethodPostProcessor.hpp"
+#include "MethodPutProcessor.hpp"
+#include "UnsupportedMethodProcessor.hpp"
 
 IRequestProcessor* RequestProcessorFactory::createRequestProcessor(
     const RequestVO& request, const LocationConfig* config, int kq,
     IObserver<ResponseVO>* ob) {
-  return new MethodGetProcessor(request, config, kq, ob);
+  const std::vector<std::string>& accepts = config->getAcceptMethods();
+  const std::string& method = request.getMethod();
+  if (std::find(accepts.begin(), accepts.end(), method) == accepts.end()) {
+    return new UnsupportedMethodProcessor(request, config, kq, ob);
+  }
+  if (method == "GET") {
+    return new MethodGetProcessor(request, config, kq, ob);
+  }
+  if (method == "POST") {
+    return new MethodPostProcessor(request, config, kq, ob);
+  }
+  if (method == "DELETE") {
+    return new MethodDeleteProcessor(request, config, kq, ob);
+  }
+  if (method == "PUT") {
+    return new MethodPutProcessor(request, config, kq, ob);
+  }
+  return new UnsupportedMethodProcessor(request, config, kq, ob);
 }


### PR DESCRIPTION
Processor를 선택하는 로직을 추가했습니다.

간단하게 `accept_methods` 지시어를 확인해 사용가능한 메소드인지 검사하고 각 메소드에 맞는 Processor를 생성하도록 만들었습니다.