### PR TITLE
fix: timeout close socket

### DIFF
--- a/src/ClientEventController.hpp
+++ b/src/ClientEventController.hpp
@@ -44,7 +44,7 @@ class ClientEventController : public EventController, public IClient {
   ClientEventController(int clientSocket);
   ClientEventController(const ClientEventController &src);
   ClientEventController &operator=(const ClientEventController &rhs);
-  void clear();
+  void clear(bool forceClose);
 };
 /*
 // 우선 key에 공백 있으면 안됨.


### PR DESCRIPTION
`response`에 `keep-alive`헤더가 있을떄 타임아웃의 상황이 와도 제대로 클라이언트의 소켓을 끊어내지 못하는 버그를 발견했습니다. 이 내용을 수정합니다.
