### PR TITLE
refactor: lol response setting

### DIFF
--- a/src/ClientEventController.cpp
+++ b/src/ClientEventController.cpp
@@ -36,7 +36,24 @@ void ClientEventController::addEventController(
 // IClient
 const Request &ClientEventController::getRequest() const { return request_; }
 
+void ClientEventController::setRequest(const Request &request) {
+  request_ = request;
+}
+
 const Response &ClientEventController::getResponse() const { return response_; }
+
+void ClientEventController::setResponse(const Response &response) {
+  response_ = response;
+}
+
+void ClientEventController::setResponseStatusCode(int code) {
+  response_.setStatusCode(code);
+}
+
+void ClientEventController::setResponseHeader(const std::string &key,
+                                              const std::string &value) {
+  response_.setHeader(key, value);
+}
 
 DataStream &ClientEventController::getDataStream() { return stream_; }
 
@@ -212,6 +229,9 @@ enum EventController::returnType ClientEventController::handleEvent(
 
 ProcessResult ClientEventController::nextProcessor() {
   ProcessResult res = processor_->process();
+  if (res.error_) {
+    return res;
+  }
   if (res.readOn_) {
     KqueueMultiplexer::getInstance().addReadEvent(clientSocket_, this);
   }
@@ -223,18 +243,6 @@ ProcessResult ClientEventController::nextProcessor() {
   }
   if (res.writeOff_) {
     KqueueMultiplexer::getInstance().removeWriteEvent(clientSocket_, this);
-  }
-  if (res.request) {
-    request_ = *res.request;
-  }
-  if (res.response) {
-    response_ = *res.response;
-  }
-  if (res.error_) {
-    return res;
-  }
-  if (res.status_ != 0) {
-    response_.setStatusCode(res.status_);
   }
   if (res.spendReadBuffer_) {
     recvBuffer_.erase(recvBuffer_.begin(),

--- a/src/ClientEventController.hpp
+++ b/src/ClientEventController.hpp
@@ -24,7 +24,11 @@ class ClientEventController : public EventController, public IClient {
   enum EventController::returnType handleEvent(const struct kevent &event);
 
   const Request &getRequest() const;
+  void setRequest(const Request &reqeust);
   const Response &getResponse() const;
+  void setResponse(const Response &response);
+  void setResponseStatusCode(int code);
+  void setResponseHeader(const std::string &key, const std::string &value);
   DataStream &getDataStream();
   const std::vector<char> &getRecvBuffer() const;
   const LocationConfig *getLocationConfig();

--- a/src/IClient.hpp
+++ b/src/IClient.hpp
@@ -12,7 +12,12 @@ class IClient {
  public:
   virtual ~IClient(){};
   virtual const Request &getRequest() const = 0;
+  virtual void setRequest(const Request &request) = 0;
   virtual const Response &getResponse() const = 0;
+  virtual void setResponse(const Response &response) = 0;
+  virtual void setResponseStatusCode(int code) = 0;
+  virtual void setResponseHeader(const std::string &key,
+                                 const std::string &value) = 0;
   virtual DataStream &getDataStream() = 0;
   virtual const std::vector<char> &getRecvBuffer() const = 0;
   virtual const LocationConfig *getLocationConfig() = 0;

--- a/src/processor/ErrorPageProcessor.hpp
+++ b/src/processor/ErrorPageProcessor.hpp
@@ -13,7 +13,6 @@ class ErrorPageProcessor : public IRequestProcessor {
   void forceProvideDefaultPage();
 
  private:
-  Response response_;
   IClient &client_;
   bool onlyUseDefaultPage_;
 };

--- a/src/processor/MethodDeleteProcessor.cpp
+++ b/src/processor/MethodDeleteProcessor.cpp
@@ -6,7 +6,7 @@
 #include "FilePath.hpp"
 
 MethodDeleteProcessor::MethodDeleteProcessor(IClient &client)
-    : client_(client), response_(client_.getResponse()) {}
+    : client_(client) {}
 
 static void deleteFile(FilePath &filepath) {
   int code = remove(filepath.c_str());
@@ -23,25 +23,25 @@ ProcessResult MethodDeleteProcessor::process() {
   // 들어온값이 directory 형태라면 실패.
   if (filepath.isDirectory()) {
     std::cout << "error: DELETE: not allow form" << std::endl;
-    return ProcessResult().setStatus(404).setNextProcessor(
-        new ErrorPageProcessor(client_));
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   FilePath directoryPath = FilePath::getDirectory(filepath);
   directoryPath = directoryPath.toDirectoryPath();
   // 들어온값이 잘못된 경로라면 실패.
   if (!directoryPath.isExist()) {
     std::cout << "error: DELETE: non exist path" << std::endl;
-    return ProcessResult().setStatus(404).setNextProcessor(
-        new ErrorPageProcessor(client_));
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 삭제할려는 파일이 존재하지않는다면 실패.
   if (!filepath.isFile()) {
     std::cout << "error: DELETE: non exits file" << std::endl;
-    return ProcessResult().setStatus(404).setNextProcessor(
-        new ErrorPageProcessor(client_));
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   deleteFile(filepath);
-  response_.setStatusCode(201);
-  client_.getDataStream().readStr(response_.toString());
-  return ProcessResult().setResponse(&response_).setWriteOn(true);
+  client_.setResponseStatusCode(201);
+  client_.getDataStream().readStr(client_.getResponse().toString());
+  return ProcessResult().setWriteOn(true);
 }

--- a/src/processor/MethodDeleteProcessor.hpp
+++ b/src/processor/MethodDeleteProcessor.hpp
@@ -14,7 +14,6 @@ class MethodDeleteProcessor : public IRequestProcessor {
 
  private:
   IClient &client_;
-  Response response_;
 };
 
 #endif

--- a/src/processor/MethodGetProcessor.hpp
+++ b/src/processor/MethodGetProcessor.hpp
@@ -18,7 +18,6 @@ class MethodGetProcessor : public IRequestProcessor {
   void createAutoindex(FilePath filename);
 
   IClient &client_;
-  Response response_;
 };
 
 #endif

--- a/src/processor/MethodPostProcessor.cpp
+++ b/src/processor/MethodPostProcessor.cpp
@@ -7,7 +7,7 @@
 #include "FilePath.hpp"
 
 MethodPostProcessor::MethodPostProcessor(IClient &client)
-    : client_(client), writer_(NULL), response_(client_.getResponse()) {}
+    : client_(client), writer_(NULL) {}
 
 MethodPostProcessor::~MethodPostProcessor() {
   if (writer_) {
@@ -26,29 +26,29 @@ ProcessResult MethodPostProcessor::process() {
   // 들어온값이 directory 형태라면 실패.
   if (filepath.isDirectory()) {
     std::cout << "error: POST: not allow form" << std::endl;
-    return ProcessResult().setStatus(404).setNextProcessor(
-        new ErrorPageProcessor(client_));
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 경로 존재 X
   FilePath directoryPath = FilePath::getDirectory(filepath);
   directoryPath = directoryPath.toDirectoryPath();
   if (!directoryPath.isExist()) {
     std::cout << "error: POST: non exist path" << std::endl;
-    return ProcessResult().setStatus(404).setNextProcessor(
-        new ErrorPageProcessor(client_));
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 들어온값에 이미 같은 이름의 파일이 존재한다면 실패.
   if (filepath.isFile()) {
     std::cout << "error: POST: Files that already exist" << std::endl;
-    return ProcessResult().setStatus(404).setNextProcessor(
-        new ErrorPageProcessor(client_));
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   std::string content = client_.getRequest().getBody();
   writer_ =
       FileWriteEventController::addEventController(filepath, content, this);
-  response_.setStatusCode(201);
-  client_.getDataStream().readStr(response_.toString());
-  return ProcessResult().setResponse(&response_).setWriteOn(true);
+  client_.setResponseStatusCode(201);
+  client_.getDataStream().readStr(client_.getResponse().toString());
+  return ProcessResult().setWriteOn(true);
 }
 
 void MethodPostProcessor::onEvent(const FileWriteEventController::Event &p) {

--- a/src/processor/MethodPostProcessor.hpp
+++ b/src/processor/MethodPostProcessor.hpp
@@ -19,7 +19,6 @@ class MethodPostProcessor : public IRequestProcessor,
  private:
   IClient &client_;
   FileWriteEventController *writer_;
-  Response response_;
 };
 
 #endif

--- a/src/processor/ParseRequestProcessor.cpp
+++ b/src/processor/ParseRequestProcessor.cpp
@@ -131,7 +131,8 @@ ProcessResult ParseRequestProcessor::process() {
         parseHeader();
       } catch (std::exception &e) {
         std::cout << "Error: parse: " << e.what() << std::endl;  // debug
-        return ProcessResult().setStatus(401).setReadOff(true).setNextProcessor(
+        client_.setResponseStatusCode(401);
+        return ProcessResult().setReadOff(true).setNextProcessor(
             new ErrorPageProcessor(client_));
       }
       std::map<std::string, std::string>::const_iterator it =
@@ -142,19 +143,17 @@ ProcessResult ParseRequestProcessor::process() {
         if ((end && *end != '\0') || contentLen < 0) {
           std::cout << "error: wrong Content-Length format"
                     << std::endl;  // debug
-          return ProcessResult()
-              .setStatus(402)
-              .setReadOff(true)
-              .setNextProcessor(new ErrorPageProcessor(client_));
+          client_.setResponseStatusCode(402);
+          return ProcessResult().setReadOff(true).setNextProcessor(
+              new ErrorPageProcessor(client_));
         }
         contentLength_ = static_cast<size_t>(contentLen);
       }
       parseBody();
       printParseResult();  // debug
-      return ProcessResult()
-          .setRequest(&request_)
-          .setReadOff(true)
-          .setNextProcessor(new SelectMethodProcessor(client_));
+      client_.setRequest(request_);
+      return ProcessResult().setReadOff(true).setNextProcessor(
+          new SelectMethodProcessor(client_));
     }
     return ProcessResult();
   } else {
@@ -163,13 +162,13 @@ ProcessResult ParseRequestProcessor::process() {
       parseBody();
     } catch (std::exception &e) {
       std::cout << "Error: parse: " << e.what() << std::endl;  // debug
-      return ProcessResult().setStatus(401).setReadOff(true).setNextProcessor(
+      client_.setResponseStatusCode(401);
+      return ProcessResult().setReadOff(true).setNextProcessor(
           new ErrorPageProcessor(client_));
     }
   }
   printParseResult();  // debug
-  return ProcessResult()
-      .setRequest(&request_)
-      .setReadOff(true)
-      .setNextProcessor(new SelectMethodProcessor(client_));
+  client_.setRequest(request_);
+  return ProcessResult().setReadOff(true).setNextProcessor(
+      new SelectMethodProcessor(client_));
 }

--- a/src/processor/ProcessResult.cpp
+++ b/src/processor/ProcessResult.cpp
@@ -7,10 +7,7 @@ ProcessResult::ProcessResult()
       readOff_(false),
       error_(false),
       spendReadBuffer_(0),
-      status_(0),
-      nextProcessor_(nullptr),
-      request(nullptr),
-      response(nullptr) {}
+      nextProcessor_(NULL) {}
 
 ProcessResult& ProcessResult::setWriteOn(bool b) {
   this->writeOn_ = b;
@@ -42,23 +39,8 @@ ProcessResult& ProcessResult::setSpendReadBuffer(unsigned spendReadBuffer) {
   return *this;
 }
 
-ProcessResult& ProcessResult::setStatus(int status) {
-  this->status_ = status;
-  return *this;
-}
-
 ProcessResult& ProcessResult::setNextProcessor(
     IRequestProcessor* nextProcessor) {
   this->nextProcessor_ = nextProcessor;
-  return *this;
-}
-
-ProcessResult& ProcessResult::setRequest(const Request* request) {
-  this->request = request;
-  return *this;
-}
-
-ProcessResult& ProcessResult::setResponse(const Response* response) {
-  this->response = response;
   return *this;
 }

--- a/src/processor/ProcessResult.hpp
+++ b/src/processor/ProcessResult.hpp
@@ -15,21 +15,15 @@ class ProcessResult {
   ProcessResult &setReadOff(bool b);
   ProcessResult &setError(bool b);
   ProcessResult &setSpendReadBuffer(unsigned spendReadBuffer);
-  ProcessResult &setStatus(int status);
   ProcessResult &setNextProcessor(IRequestProcessor *nextProcessor);
-  ProcessResult &setRequest(const Request *request);
-  ProcessResult &setResponse(const Response *response);
 
-  bool writeOn_;              // suggest write on
-  bool writeOff_;             // suggest write off
-  bool readOn_;               // suggest read on
-  bool readOff_;              // suggest read off
-  bool error_;                // occur critical error (close socket)
-  int spendReadBuffer_;          // spend read size from client recvBuffer
-  int status_;                        // status code
+  bool writeOn_;                      // suggest write on
+  bool writeOff_;                     // suggest write off
+  bool readOn_;                       // suggest read on
+  bool readOff_;                      // suggest read off
+  bool error_;                        // occur critical error (close socket)
+  int spendReadBuffer_;               // spend read size from client recvBuffer
   IRequestProcessor *nextProcessor_;  // delete this and run next processor
-  const Request *request;             // cover this
-  const Response *response;           // cover this
 };
 
 #endif

--- a/src/processor/ProvideFileProcessor.hpp
+++ b/src/processor/ProvideFileProcessor.hpp
@@ -10,8 +10,7 @@
 class ProvideFileProcessor : public IRequestProcessor,
                              public IObserver<FileReadEventController::Event> {
  public:
-  ProvideFileProcessor(IClient &client, const FilePath &path,
-                       const Response &response);
+  ProvideFileProcessor(IClient &client, const FilePath &path);
   ~ProvideFileProcessor();
   ProcessResult process();
   void onEvent(const FileReadEventController::Event &e);
@@ -19,7 +18,6 @@ class ProvideFileProcessor : public IRequestProcessor,
  private:
   IClient &client_;
   FilePath path_;
-  Response response_;
   FileReadEventController *reader_;
   int fileSize_;
   bool fatalError_;

--- a/src/processor/RedirectionProcessor.cpp
+++ b/src/processor/RedirectionProcessor.cpp
@@ -7,14 +7,11 @@ RedirectionProcessor::RedirectionProcessor(IClient& client) : client_(client) {}
 ProcessResult RedirectionProcessor::process() {
   int status = client_.getLocationConfig()->getRedirectionStatusCode();
   std::string path = client_.getLocationConfig()->getRedirectionPath();
-  response_ = client_.getResponse();
-  response_.setStatusCode(status);
-  response_.setHeader("Location", path);
-  response_.setHeader("Content-Length", "0");
-  client_.getDataStream().readStr(response_.toString());
+  Response response = client_.getResponse();
+  client_.setResponseStatusCode(status);
+  client_.setResponseHeader("Location", path);
+  client_.setResponseHeader("Content-Length", "0");
+  client_.getDataStream().readStr(response.toString());
   client_.getDataStream().setEof(true);
-  return ProcessResult()
-      .setWriteOn(true)
-      .setResponse(&response_)
-      .setNextProcessor(new WaitProcessor());
+  return ProcessResult().setWriteOn(true).setNextProcessor(new WaitProcessor());
 }

--- a/src/processor/RedirectionProcessor.hpp
+++ b/src/processor/RedirectionProcessor.hpp
@@ -11,7 +11,6 @@ class RedirectionProcessor : public IRequestProcessor {
 
  private:
   IClient &client_;
-  Response response_;
 };
 
 #endif

--- a/src/processor/SelectMethodProcessor.hpp
+++ b/src/processor/SelectMethodProcessor.hpp
@@ -11,7 +11,6 @@ class SelectMethodProcessor : public IRequestProcessor {
 
  private:
   IClient &client_;
-  Response response_;
 };
 
 #endif

--- a/src/processor/StartProcessor.cpp
+++ b/src/processor/StartProcessor.cpp
@@ -2,16 +2,15 @@
 
 #include "ParseRequestProcessor.hpp"
 
-StartProcessor::StartProcessor(IClient& client)
-    : client_(client), response_(client.getResponse()) {}
+StartProcessor::StartProcessor(IClient& client) : client_(client) {}
 
 ProcessResult StartProcessor::process() {
-  response_.setVersion("HTTP/1.1");
-  response_.setStatusCode(100);
-  response_.setHeader("Server", "irc");
-  response_.setHeader("Connection", "keep-alive");
-  response_.setHeader("Content-Type", "text/html");
-  return ProcessResult()
-      .setResponse(&response_)
-      .setNextProcessor(new ParseRequestProcessor(client_));
+  Response response = client_.getResponse();
+  response.setVersion("HTTP/1.1");
+  response.setStatusCode(100);
+  response.setHeader("Server", "irc");
+  response.setHeader("Connection", "keep-alive");
+  response.setHeader("Content-Type", "text/html");
+  client_.setResponse(response);
+  return ProcessResult().setNextProcessor(new ParseRequestProcessor(client_));
 };

--- a/src/processor/StartProcessor.hpp
+++ b/src/processor/StartProcessor.hpp
@@ -12,7 +12,6 @@ class StartProcessor : public IRequestProcessor {
 
  private:
   IClient &client_;
-  Response response_;
 };
 
 #endif


### PR DESCRIPTION
각 `Processor`에서 `Response`를 세팅하는 방법을 수정하셨습니다.
다음과 같은 이점을 얻을 수 있습니다.
- Response 복사 생성자 호출 횟수 감소
- Response 를 복사하여 관리하지 않고 Client의 Response에 바로 접근
