### PR TITLE
feat/signal sigpipe

### DIFF
--- a/src/ServerEventController.cpp
+++ b/src/ServerEventController.cpp
@@ -49,13 +49,13 @@ enum EventController::returnType ServerEventController::handleEvent(
   sockaddr_in client_addr;
   client_addr_size = sizeof(client_addr);  // client 주소의 크기
 
-  std::cout << "---------- client accept" << std::endl;
   int clientSocket =
       accept(event.ident, (struct sockaddr *)&client_addr, &client_addr_size);
   if (clientSocket == -1) {
     std::cout << "accept error" << std::endl;
     return PENDING;
   }
+  std::cout << "---------- client accept(" << clientSocket << ")" << std::endl;
   ClientEventController::addEventController(clientSocket, getServerConfigs());
   return PENDING;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
     Directive directive = ConfigLexer::run(configStr);
     RootConfig config = ConfigMaker::makeConfig(directive);
     config.printRootConfig();  // debug
+    signal(SIGPIPE, SIG_IGN);
     run(config);
   } catch (...) {
     return 1;


### PR DESCRIPTION
클라이언트가 먼저 소켓을 끊을 경우 write를 실패하며 SIGPIPE를 받아 프로그램이 종료되는 상황이 잦습니다.
이 버그를 수정했습니다.
- feat: handle sigpipe
- chore: debug print accept socket
