### PR TITLE
fix: config null guard

### DIFF
--- a/src/processor/ErrorPageProcessor.cpp
+++ b/src/processor/ErrorPageProcessor.cpp
@@ -24,13 +24,16 @@ ProcessResult ErrorPageProcessor::process() {
   const int code = response.getStatusCode();
   const std::string msg = response.getStatusMsg();
 
-  FilePath errorPagePath = client_.getLocationConfig()->getErrorPage(code);
-  FilePath absolutePath = client_.getLocationConfig()->getRootPath();
-  absolutePath.appendPath(errorPagePath);
-  if (onlyUseDefaultPage_ == false && errorPagePath.empty() == false &&
-      absolutePath.isFile() && absolutePath.isAccessible(FilePath::READ)) {
-    return ProcessResult().setNextProcessor(
-        new ProvideFileProcessor(client_, absolutePath));
+  const LocationConfig* config = client_.getLocationConfig();
+  if (config != NULL) {
+    FilePath errorPagePath = config->getErrorPage(code);
+    FilePath absolutePath = config->getRootPath();
+    absolutePath.appendPath(errorPagePath);
+    if (onlyUseDefaultPage_ == false && errorPagePath.empty() == false &&
+        absolutePath.isFile() && absolutePath.isAccessible(FilePath::READ)) {
+      return ProcessResult().setNextProcessor(
+          new ProvideFileProcessor(client_, absolutePath));
+    }
   }
   std::stringstream ss;
   ss << "<html>" << CRLF;


### PR DESCRIPTION
- #49
`ErrorPageProcessor.cpp`에서 에러페이지 처리시 `config`가 `NULL`인지 확인하고 진행하도록 수정했습니다.
