### PR TITLE
Feat/logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ PROCESSOR_NAME := \
 
 UTIL_DIR := $(SRC_DIR)/util/
 UTIL_NAME := \
+	Log.cpp \
 	String.cpp \
 	FilePath.cpp \
 	DataStream.cpp \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_DIR := build
 CXX := c++
 CXXFLAGS := -std=c++98 -Wall -Wextra -Werror -MMD -MP -g3 $(INC_DIR)
 ifdef DEBUG
-CXXFLAGS += -fsanitize=address
+CXXFLAGS += -fsanitize=address -DLOG_LEVEL=4
 endif
 
 # ===============================================
@@ -154,6 +154,6 @@ re:
 
 debug:
 	$(MAKE) fclean
-	$(MAKE) -j DEBUG=1
+	$(MAKE) -j DEBUG=1 LOG_LEVEL=1
 
 .PHONY: all clean fclean re debug

--- a/src/CgiEventController.cpp
+++ b/src/CgiEventController.cpp
@@ -14,6 +14,7 @@
 #include "CgiInProcessor.hpp"
 #include "FilePath.hpp"
 #include "IObserver.hpp"
+#include "Log.hpp"
 #include "Multiplexer.hpp"
 
 CgiEventController::CgiEventController(
@@ -48,7 +49,7 @@ void CgiEventController::init() {
   socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
   pid_ = fork();
   if (pid_ == -1) {
-    std::cerr << "debug fork error" << std::endl;
+    Log::error << "fork error" << NL;
     throw std::runtime_error("fork error");
   }
 

--- a/src/CgiEventController.cpp
+++ b/src/CgiEventController.cpp
@@ -167,6 +167,10 @@ void CgiEventController::clear(bool error) {
   Multiplexer::getInstance().addDeleteController(this);
 }
 
+void CgiEventController::print(Log& logger, const std::string& msg) {
+  logger << fd_ << ": " << msg << NL;
+}
+
 CgiEventController::Event& CgiEventController::Event::setError(bool error) {
   error_ = error;
   return *this;

--- a/src/CgiEventController.hpp
+++ b/src/CgiEventController.hpp
@@ -34,6 +34,7 @@ class CgiEventController : public EventController,
   void end();
   DataStream &getWriteBuffer();
   void clear(bool error);
+  void print(Log &logger, const std::string &msg);
 
  private:
   CgiEventController(IClient &client,

--- a/src/ClientEventController.cpp
+++ b/src/ClientEventController.cpp
@@ -132,7 +132,7 @@ const LocationConfig *ClientEventController::getLocationConfig() {
     }
     config_ = selectLocationConfig(serverConfig->getLocationConfigs(),
                                    String(request_.getUri()).trim());
-    Log::debug << fd_ << ": selected location path: " << config_->getUri()
+    Log::debug << fd_ << ":  selected location path: " << config_->getUri()
                << NL;
   }
   return config_;

--- a/src/ClientEventController.cpp
+++ b/src/ClientEventController.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 
 #include "EventController.hpp"
+#include "Log.hpp"
 #include "StartProcessor.hpp"
 #include "String.hpp"
 
@@ -131,8 +132,8 @@ const LocationConfig *ClientEventController::getLocationConfig() {
     }
     config_ = selectLocationConfig(serverConfig->getLocationConfigs(),
                                    String(request_.getUri()).trim());
-    std::cout << "debug - selected location path: " << config_->getUri()
-              << std::endl;
+    Log::debug << fd_ << ": selected location path: " << config_->getUri()
+               << NL;
   }
   return config_;
 }
@@ -153,12 +154,11 @@ void ClientEventController::handleEvent(const Multiplexer::Event &event) {
     recvBuffer.resize(MAX_BUFFER_SIZE);
     int size = recv(fd_, recvBuffer.data(), MAX_BUFFER_SIZE, 0);
     if (size == -1) {
-      std::cout << "debug: read error" << std::endl;
+      print(Log::info, "read error");
       clear(true);
       return;
     }
     if (size == 0) {
-      std::cout << "debug: closed socket(" << fd_ << ")" << std::endl;
       clear(true);
       return;
     }
@@ -177,7 +177,7 @@ void ClientEventController::handleEvent(const Multiplexer::Event &event) {
     }
   }
   if (event.filter == WEB_TIMEOUT) {
-    std::cout << "debug: timeout - close client" << std::endl;
+    print(Log::info, "timeout");
     clear(true);
 
     return;
@@ -196,11 +196,13 @@ void ClientEventController::clear(bool forceClose) {
     ClientEventController *client =
         ClientEventController::addEventController(fd_, serverConfigs_);
     if (client == NULL) {
+      print(Log::info, "close socket");
       close(fd_);
       return;
     }
     client->getRecvBuffer().addBuffer(getRecvBuffer().getBuffer());
   } else {
+    print(Log::info, "close socket");
     close(fd_);
   }
 }

--- a/src/ClientEventController.cpp
+++ b/src/ClientEventController.cpp
@@ -137,6 +137,10 @@ const LocationConfig *ClientEventController::getLocationConfig() {
   return config_;
 }
 
+void ClientEventController::print(Log &logger, const std::string &msg) {
+  logger << fd_ << ": " << msg << NL;
+}
+
 void ClientEventController::init() {
   if (loopProcess()) {
     throw std::logic_error("error: init client event controller");

--- a/src/ClientEventController.hpp
+++ b/src/ClientEventController.hpp
@@ -36,6 +36,7 @@ class ClientEventController : public EventController, public IClient {
   DataStream &getDataStream();
   StringBuffer &getRecvBuffer();
   const LocationConfig *getLocationConfig();
+  void print(Log &logger, const std::string &msg);
 
  private:
   const LocationConfig *config_;

--- a/src/ICgi.hpp
+++ b/src/ICgi.hpp
@@ -4,6 +4,7 @@
 #define CGI_RECV_BUFFER 8192
 
 #include "DataStream.hpp"
+#include "Log.hpp"
 #include "StringBuffer.hpp"
 
 class ICgi {
@@ -15,6 +16,7 @@ class ICgi {
   virtual StringBuffer &getRecvBuffer() = 0;
   virtual void end() = 0;
   virtual DataStream &getWriteBuffer() = 0;
+  virtual void print(Log &logger, const std::string &msg) = 0;
 };
 
 #endif

--- a/src/IClient.hpp
+++ b/src/IClient.hpp
@@ -5,6 +5,7 @@
 
 #include "DataStream.hpp"
 #include "LocationConfig.hpp"
+#include "Log.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
 #include "StringBuffer.hpp"
@@ -24,6 +25,7 @@ class IClient {
   virtual DataStream &getDataStream() = 0;
   virtual StringBuffer &getRecvBuffer() = 0;
   virtual const LocationConfig *getLocationConfig() = 0;
+  virtual void print(Log &logger, const std::string &msg) = 0;
 };
 
 #endif

--- a/src/ServerEventController.cpp
+++ b/src/ServerEventController.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 
 #include "AcceptClientProcessor.hpp"
+#include "Log.hpp"
 #include "Multiplexer.hpp"
 
 ServerEventController::ServerEventController(int port)
@@ -69,11 +70,11 @@ void ServerEventController::init() {
 
 void ServerEventController::handleEvent(const Multiplexer::Event &event) {
   if (event.filter == WEB_WRITE || event.filter == WEB_TIMEOUT) {
-    std::cerr << "invalid server filter" << std::endl;
+    Log::error << "invalid server filter" << NL;
     return;
   }
   if (loopProcess()) {
-    std::cout << "accept error" << std::endl;
+    Log::error << "accept error" << NL;
   }
 }
 

--- a/src/config/LocationConfig.cpp
+++ b/src/config/LocationConfig.cpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 
+#include "Log.hpp"
 #include "ServerConfig.hpp"
 
 LocationConfig::LocationConfig(const ServerConfig &src)
@@ -36,35 +37,35 @@ LocationConfig &LocationConfig::operator=(const LocationConfig &rhs) {
 LocationConfig::~LocationConfig(void) {}
 
 void LocationConfig::printLocationConfig(void) {
-  std::cout << "  location " << uri_ << " {" << '\n';
-  std::cout << "    root: " << rootPath_ << '\n';
-  std::cout << "    client_max_body_size: " << limitClientBodySize_ << '\n';
-  std::cout << "    return " << redirectionStatusCode_ << ' '
-            << redirectionPath_ << '\n';
-  std::cout << "    index: " << indexPath_ << '\n';
-  std::cout << "    autoindex: " << std::boolalpha << autoindex_ << '\n';
-  std::cout << "    accept_methods ";
+  Log::debug << "  location " << uri_ << " {" << NL;
+  Log::debug << "    root: " << rootPath_ << NL;
+  Log::debug << "    client_max_body_size: " << limitClientBodySize_ << NL;
+  Log::debug << "    return " << redirectionStatusCode_ << ' '
+             << redirectionPath_ << NL;
+  Log::debug << "    index: " << indexPath_ << NL;
+  Log::debug << "    autoindex: " << std::boolalpha << autoindex_ << NL;
+  Log::debug << "    accept_methods ";
   std::vector<std::string>::iterator method;
   for (method = acceptMethods_.begin(); method != acceptMethods_.end();
        method++) {
-    std::cout << *method << ' ';
+    Log::debug << *method << ' ';
   }
-  std::cout << '\n';
+  Log::debug << NL;
   std::map<std::string, std::string>::iterator cgi;
   for (cgi = this->cgiPrograms_.begin(); cgi != this->cgiPrograms_.end();
        cgi++) {
-    std::cout << "    cgi_extension " << cgi->first << ' ' << cgi->second
-              << '\n';
+    Log::debug << "    cgi_extension " << cgi->first << ' ' << cgi->second
+               << NL;
   }
   std::map<int, std::string>::const_iterator errorPage;
   for (errorPage = errorPages_.begin(); errorPage != errorPages_.end();
        errorPage++) {
     std::stringstream ss;
     ss << errorPage->first;
-    std::cout << "    error_page: " << ss.str() << " " << errorPage->second
-              << '\n';
+    Log::debug << "    error_page: " << ss.str() << " " << errorPage->second
+               << NL;
   }
-  std::cout << "  }" << '\n';
+  Log::debug << "  }" << NL;
 }
 
 int LocationConfig::getLimitClientBodySize() const {

--- a/src/config/RootConfig.cpp
+++ b/src/config/RootConfig.cpp
@@ -2,6 +2,8 @@
 
 #include <sstream>
 
+#include "Log.hpp"
+
 RootConfig::RootConfig()
     : limitClientBodySize_(1 * 1024 * 1024), autoindex_(false) {}
 
@@ -23,15 +25,15 @@ RootConfig::~RootConfig() {}
 
 void RootConfig::printRootConfig() {
   std::vector<ServerConfig>::iterator server;
-  std::cout << "root: " << this->rootPath_ << '\n';
-  std::cout << "client_max_body_size: " << this->limitClientBodySize_ << '\n';
-  std::cout << "autoindex: " << std::boolalpha << autoindex_ << '\n';
+  Log::debug << "root: " << this->rootPath_ << NL;
+  Log::debug << "client_max_body_size: " << this->limitClientBodySize_ << NL;
+  Log::debug << "autoindex: " << std::boolalpha << autoindex_ << NL;
   std::map<int, std::string>::const_iterator errorPage;
   for (errorPage = errorPages_.begin(); errorPage != errorPages_.end();
        errorPage++) {
     std::stringstream ss;
     ss << errorPage->first;
-    std::cout << "error_page: " << ss.str() << " " << errorPage->second << '\n';
+    Log::debug << "error_page: " << ss.str() << " " << errorPage->second << NL;
   }
   for (server = this->serverConfigs_.begin();
        server != this->serverConfigs_.end(); server++) {

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -2,6 +2,7 @@
 
 #include <sstream>
 
+#include "Log.hpp"
 #include "RootConfig.hpp"
 
 ServerConfig::ServerConfig(const RootConfig &src)
@@ -35,27 +36,27 @@ ServerConfig &ServerConfig::operator=(const ServerConfig &rhs) {
 ServerConfig::~ServerConfig(void) {}
 
 void ServerConfig::printServerConfig(void) {
-  std::cout << "server {" << '\n';
-  std::cout << "  root: " << this->rootPath_ << '\n';
-  std::cout << "  server_name: " << this->serverName_ << '\n';
-  std::cout << "  client_max_body_size: " << this->limitClientBodySize_ << '\n';
-  std::cout << "  listen: " << this->port_ << '\n';
-  std::cout << "  autoindex: " << std::boolalpha << this->autoindex_ << '\n';
-  std::cout << "  index: " << this->index_ << '\n';
+  Log::debug << "server {" << NL;
+  Log::debug << "  root: " << this->rootPath_ << NL;
+  Log::debug << "  server_name: " << this->serverName_ << NL;
+  Log::debug << "  client_max_body_size: " << this->limitClientBodySize_ << NL;
+  Log::debug << "  listen: " << this->port_ << NL;
+  Log::debug << "  autoindex: " << std::boolalpha << this->autoindex_ << NL;
+  Log::debug << "  index: " << this->index_ << NL;
   std::map<int, std::string>::const_iterator errorPage;
   for (errorPage = errorPages_.begin(); errorPage != errorPages_.end();
        errorPage++) {
     std::stringstream ss;
     ss << errorPage->first;
-    std::cout << "  error_page: " << ss.str() << " " << errorPage->second
-              << '\n';
+    Log::debug << "  error_page: " << ss.str() << " " << errorPage->second
+               << NL;
   }
   std::vector<LocationConfig>::iterator location;
   for (location = locationConfigs_.begin(); location != locationConfigs_.end();
        location++) {
     location->printLocationConfig();
   }
-  std::cout << '}' << '\n';
+  Log::debug << '}' << NL;
 }
 
 void ServerConfig::setAutoindex(const std::string &autoindex) {

--- a/src/config/configChecker/ConfigChecker.cpp
+++ b/src/config/configChecker/ConfigChecker.cpp
@@ -13,6 +13,7 @@
 
 #include "Directive.hpp"
 #include "FilePath.hpp"
+#include "Log.hpp"
 
 // asset
 
@@ -235,7 +236,7 @@ void ConfigChecker::checkDirective(Directive directive) {
     }
     checkDirectiveChildren(directive);
   } catch (const std::exception &e) {
-    std::cout << "Error: Config: " << e.what() << '\n';
+    Log::error << "Config: " << e.what() << NL;
     throw e;
   }
 }

--- a/src/config/configLexer/ConfigLexer.cpp
+++ b/src/config/configLexer/ConfigLexer.cpp
@@ -3,6 +3,7 @@
 #include <exception>
 #include <vector>
 
+#include "Log.hpp"
 #include "ParseResult.hpp"
 #include "Parser.hpp"
 #include "PatternLetters.hpp"
@@ -181,7 +182,7 @@ const Directive ConfigLexer::run(const std::string raw) {
     ParseResult result = configParser.compile("httpBlock", raw);
     return parseResultToDirective(result);
   } catch (std::invalid_argument &e) {
-    std::cout << e.what() << std::endl;
+    Log::error << "ConfigLexer: " << e.what() << NL;
     throw e;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 
 #include "ConfigLexer.hpp"
 #include "ConfigMaker.hpp"
+#include "Log.hpp"
 #include "Multiplexer.hpp"
 #include "RootConfig.hpp"
 #include "ServerConfig.hpp"
@@ -57,12 +58,12 @@ int main(int argc, char **argv) {
   } else if (argc == 2) {
     filepath = argv[1];
   } else {
-    std::cout << "Error: too many args" << std::endl;
+    Log::error << "too many args" << NL;
     return 1;
   }
   std::ifstream configFile(filepath.c_str());
   if (!configFile.is_open()) {
-    std::cout << "Error: config file open error" << std::endl;
+    Log::error << "config file open error" << NL;
     return 1;
   }
   std::string configStr((std::istreambuf_iterator<char>(configFile)),
@@ -75,7 +76,7 @@ int main(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
     run(config);
   } catch (const std::exception &e) {
-    std::cout << e.what() << std::endl;
+    Log::error << "error: " << e.what() << NL;
     return 1;
   }
   return 0;

--- a/src/processor/AcceptClientProcessor.cpp
+++ b/src/processor/AcceptClientProcessor.cpp
@@ -1,6 +1,7 @@
 #include "AcceptClientProcessor.hpp"
 
 #include "ClientEventController.hpp"
+#include "Log.hpp"
 
 AcceptClientProcessor::AcceptClientProcessor(IServer& server)
     : server_(server) {}
@@ -14,6 +15,6 @@ ProcessResult AcceptClientProcessor::process() {
           clientSocket, server_.getServerConfigs()) == NULL) {
     return ProcessResult().setError(true);
   }
-  std::cout << "---------- client accept(" << clientSocket << ")" << std::endl;
+  Log::info << clientSocket << ": client accepted" << NL;
   return ProcessResult();
 }

--- a/src/processor/CgiInProcessor.cpp
+++ b/src/processor/CgiInProcessor.cpp
@@ -7,7 +7,9 @@
 #include "ErrorPageProcessor.hpp"
 
 CgiInProcessor::CgiInProcessor(ICgi& cgi, IClient& client)
-    : client_(client), cgi_(cgi), isPushStr_(false) {}
+    : client_(client), cgi_(cgi), isPushStr_(false) {
+  cgi_.print(Log::info, "  CgiInProcessor");
+}
 
 /*
 이 함수에서 writeBuffer에 값을 채워넣는 역할.

--- a/src/processor/CgiOutProcessor.cpp
+++ b/src/processor/CgiOutProcessor.cpp
@@ -6,7 +6,9 @@
 #include "WaitProcessor.hpp"
 
 CgiOutProcessor::CgiOutProcessor(ICgi& cgi, IClient& client)
-    : cgi_(cgi), client_(client) {}
+    : cgi_(cgi), client_(client) {
+  client_.print(Log::info, "  CgiOutProcessor");
+}
 
 ProcessResult CgiOutProcessor::process() {
   String rawHeaders = cgi_.getRecvBuffer().nextSeek("\r\n\r\n");

--- a/src/processor/CgiProcessor.cpp
+++ b/src/processor/CgiProcessor.cpp
@@ -6,7 +6,9 @@
 #include "WaitProcessor.hpp"
 
 CgiProcessor::CgiProcessor(IClient& client)
-    : client_(client), cgi_(NULL), error_(false), end_(false) {}
+    : client_(client), cgi_(NULL), error_(false), end_(false) {
+  client_.print(Log::info, " CgiProcessor");
+}
 
 CgiProcessor::~CgiProcessor() {
   if (cgi_) {

--- a/src/processor/ErrorPageProcessor.cpp
+++ b/src/processor/ErrorPageProcessor.cpp
@@ -10,7 +10,11 @@
 #include "WaitProcessor.hpp"
 
 ErrorPageProcessor::ErrorPageProcessor(IClient& client)
-    : client_(client), onlyUseDefaultPage_(false) {}
+    : client_(client), onlyUseDefaultPage_(false) {
+  std::stringstream ss;
+  ss << " ErrorPageProcessor(" << client_.getResponse().getStatusCode() << ")";
+  client_.print(Log::info, ss.str());
+}
 
 static std::string intToString(int number) {
   std::stringstream ss;

--- a/src/processor/MethodDeleteProcessor.cpp
+++ b/src/processor/MethodDeleteProcessor.cpp
@@ -14,29 +14,29 @@ static void deleteFile(FilePath &filepath) {
   if (code != 0) {
     throw std::invalid_argument("file remove error");
   }
-  std::cout << "delete success" << filepath << std::endl;
+  Log::debug << "delete success" << filepath << NL;
 }
 
 ProcessResult MethodDeleteProcessor::process() {
-  std::cout << "in delete method" << std::endl;
+  client_.print(Log::debug, "in delete method");
   FilePath filepath = client_.getLocationConfig()->getRootPath();
   filepath.append(client_.getRequest().getUri());
   // 들어온값이 directory 형태라면 실패.
   if (filepath.isDirectory()) {
-    std::cout << "error: DELETE: not allowed form" << std::endl;
+    client_.print(Log::debug, "DELETE: not allowed form");
     client_.setResponseStatusCode(404);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   FilePath directoryPath = FilePath::getDirectory(filepath);
   directoryPath = directoryPath.toDirectoryPath();
   if (!directoryPath.isExist()) {
-    std::cout << "error: DELETE: Forbidden" << std::endl;
+    client_.print(Log::debug, "DELETE: Forbidden");
     client_.setResponseStatusCode(403);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 삭제할려는 파일이 존재하지않는다면 실패.
   if (!filepath.isFile()) {
-    std::cout << "error: DELETE: non exits file" << std::endl;
+    client_.print(Log::debug, "DELETE: non exits file");
     client_.setResponseStatusCode(204);  // 204 No Content
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }

--- a/src/processor/MethodDeleteProcessor.cpp
+++ b/src/processor/MethodDeleteProcessor.cpp
@@ -7,7 +7,9 @@
 #include "WaitProcessor.hpp"
 
 MethodDeleteProcessor::MethodDeleteProcessor(IClient &client)
-    : client_(client) {}
+    : client_(client) {
+  client_.print(Log::info, " MethodDeleteProcessor");
+}
 
 static void deleteFile(FilePath &filepath) {
   int code = remove(filepath.c_str());

--- a/src/processor/MethodDeleteProcessor.cpp
+++ b/src/processor/MethodDeleteProcessor.cpp
@@ -16,29 +16,29 @@ static void deleteFile(FilePath &filepath) {
   if (code != 0) {
     throw std::invalid_argument("file remove error");
   }
-  Log::debug << "delete success" << filepath << NL;
+  Log::debug << " delete success" << filepath << NL;
 }
 
 ProcessResult MethodDeleteProcessor::process() {
-  client_.print(Log::debug, "in delete method");
+  client_.print(Log::debug, " in delete method");
   FilePath filepath = client_.getLocationConfig()->getRootPath();
   filepath.append(client_.getRequest().getUri());
   // 들어온값이 directory 형태라면 실패.
   if (filepath.isDirectory()) {
-    client_.print(Log::debug, "DELETE: not allowed form");
+    client_.print(Log::debug, " DELETE: not allowed form");
     client_.setResponseStatusCode(404);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   FilePath directoryPath = FilePath::getDirectory(filepath);
   directoryPath = directoryPath.toDirectoryPath();
   if (!directoryPath.isExist()) {
-    client_.print(Log::debug, "DELETE: Forbidden");
+    client_.print(Log::debug, " DELETE: Forbidden");
     client_.setResponseStatusCode(403);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 삭제할려는 파일이 존재하지않는다면 실패.
   if (!filepath.isFile()) {
-    client_.print(Log::debug, "DELETE: non exits file");
+    client_.print(Log::debug, " DELETE: non exits file");
     client_.setResponseStatusCode(204);  // 204 No Content
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }

--- a/src/processor/MethodGetProcessor.cpp
+++ b/src/processor/MethodGetProcessor.cpp
@@ -10,7 +10,9 @@
 #include "ProvideFileProcessor.hpp"
 #include "WaitProcessor.hpp"
 
-MethodGetProcessor::MethodGetProcessor(IClient& client) : client_(client) {}
+MethodGetProcessor::MethodGetProcessor(IClient& client) : client_(client) {
+  client_.print(Log::info, " MethodGetProcessor");
+}
 
 ProcessResult MethodGetProcessor::process() {
   FilePath path = client_.getLocationConfig()->getRootPath();

--- a/src/processor/MethodGetProcessor.cpp
+++ b/src/processor/MethodGetProcessor.cpp
@@ -47,7 +47,7 @@ void MethodGetProcessor::createAutoindex(FilePath path) {
       throw std::invalid_argument("wrong path");
     }
   } catch (const std::exception& e) {
-    std::cout << "Error: GET: " << e.what() << '\n';
+    client_.print(Log::error, std::string("GET: ") + e.what());
     return;
   }
   std::string html =

--- a/src/processor/MethodPostProcessor.cpp
+++ b/src/processor/MethodPostProcessor.cpp
@@ -24,7 +24,7 @@ ProcessResult MethodPostProcessor::process() {
   filepath.append(client_.getRequest().getUri());
   // 들어온값이 directory 형태라면 실패.
   if (filepath.isDirectory()) {
-    client_.print(Log::debug, "POST: not allowed form");
+    client_.print(Log::debug, " POST: not allowed form");
     client_.setResponseStatusCode(400);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
@@ -32,13 +32,13 @@ ProcessResult MethodPostProcessor::process() {
   FilePath directoryPath = FilePath::getDirectory(filepath);
   directoryPath = directoryPath.toDirectoryPath();
   if (!directoryPath.isExist()) {
-    client_.print(Log::debug, "POST: Forbidden");
+    client_.print(Log::debug, " POST: Forbidden");
     client_.setResponseStatusCode(403);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 들어온값에 이미 같은 이름의 파일이 존재한다면 실패.
   if (filepath.isFile()) {
-    client_.print(Log::debug, "POST: Files that already exist");
+    client_.print(Log::debug, " POST: Files that already exist");
     client_.setResponseStatusCode(409);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }

--- a/src/processor/MethodPostProcessor.cpp
+++ b/src/processor/MethodPostProcessor.cpp
@@ -22,7 +22,7 @@ ProcessResult MethodPostProcessor::process() {
   filepath.append(client_.getRequest().getUri());
   // 들어온값이 directory 형태라면 실패.
   if (filepath.isDirectory()) {
-    std::cout << "error: POST: not allowed form" << std::endl;
+    client_.print(Log::debug, "POST: not allowed form");
     client_.setResponseStatusCode(400);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
@@ -30,13 +30,13 @@ ProcessResult MethodPostProcessor::process() {
   FilePath directoryPath = FilePath::getDirectory(filepath);
   directoryPath = directoryPath.toDirectoryPath();
   if (!directoryPath.isExist()) {
-    std::cout << "error: POST: Forbidden" << std::endl;
+    client_.print(Log::debug, "POST: Forbidden");
     client_.setResponseStatusCode(403);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
   // 들어온값에 이미 같은 이름의 파일이 존재한다면 실패.
   if (filepath.isFile()) {
-    std::cout << "error: POST: Files that already exist" << std::endl;
+    client_.print(Log::debug, "POST: Files that already exist");
     client_.setResponseStatusCode(409);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }

--- a/src/processor/MethodPostProcessor.cpp
+++ b/src/processor/MethodPostProcessor.cpp
@@ -7,7 +7,9 @@
 #include "FilePath.hpp"
 
 MethodPostProcessor::MethodPostProcessor(IClient &client)
-    : file_(), client_(client) {}
+    : file_(), client_(client) {
+  client_.print(Log::info, " MethodPostProcessor");
+}
 
 MethodPostProcessor::~MethodPostProcessor() {
   if (file_.is_open()) {

--- a/src/processor/ParseRequestBodyProcessor.cpp
+++ b/src/processor/ParseRequestBodyProcessor.cpp
@@ -10,7 +10,9 @@ ParseRequestBodyProcessor::ParseRequestBodyProcessor(IClient& client)
     : readStatus_(HEADER),
       contentLength_(0),
       client_(client),
-      request_(client.getRequest()) {}
+      request_(client.getRequest()) {
+  client_.print(Log::info, " ParseRequestBodyProcessor");
+}
 
 ProcessResult ParseRequestBodyProcessor::process() {
   try {

--- a/src/processor/ParseRequestBodyProcessor.cpp
+++ b/src/processor/ParseRequestBodyProcessor.cpp
@@ -58,7 +58,7 @@ void ParseRequestBodyProcessor::parseBody() {
 }
 
 void ParseRequestBodyProcessor::printParseBodyResult() {
-  std::cout << "========Body=========\n";
-  std::cout << body_ << "$" << std::endl;
-  std::cout << "=====================\n";
+  client_.print(Log::debug, "========Body=========");
+  client_.print(Log::debug, body_ + "$");
+  client_.print(Log::debug, "=====================");
 }

--- a/src/processor/ParseRequestBodyProcessor.cpp
+++ b/src/processor/ParseRequestBodyProcessor.cpp
@@ -60,7 +60,7 @@ void ParseRequestBodyProcessor::parseBody() {
 }
 
 void ParseRequestBodyProcessor::printParseBodyResult() {
-  client_.print(Log::debug, "========Body=========");
-  client_.print(Log::debug, body_ + "$");
-  client_.print(Log::debug, "=====================");
+  client_.print(Log::debug, " ========Body=========");
+  client_.print(Log::debug, " " + body_ + "$");
+  client_.print(Log::debug, " =====================");
 }

--- a/src/processor/ParseRequestChunkProcessor.cpp
+++ b/src/processor/ParseRequestChunkProcessor.cpp
@@ -9,7 +9,9 @@ ParseRequestChunkProcessor::ParseRequestChunkProcessor(IClient& client)
     : readStatus_(SIZE_LINE),
       chunkLength_(0),
       client_(client),
-      request_(client.getRequest()) {}
+      request_(client.getRequest()) {
+  client_.print(Log::info, " ParseRequestChunkProcessor");
+}
 
 ProcessResult ParseRequestChunkProcessor::process() {
   if (readStatus_ == SIZE_LINE && sizeLine_.empty()) {

--- a/src/processor/ParseRequestChunkProcessor.cpp
+++ b/src/processor/ParseRequestChunkProcessor.cpp
@@ -76,7 +76,7 @@ void ParseRequestChunkProcessor::parseChunk() {
 }
 
 void ParseRequestChunkProcessor::printParseBodyResult() {
-  client_.print(Log::debug, "========Body=========");
-  client_.print(Log::debug, chunk_ + "$");
-  client_.print(Log::debug, "=====================");
+  client_.print(Log::debug, " ========Body=========");
+  client_.print(Log::debug, " " + chunk_ + "$");
+  client_.print(Log::debug, " =====================");
 }

--- a/src/processor/ParseRequestChunkProcessor.cpp
+++ b/src/processor/ParseRequestChunkProcessor.cpp
@@ -74,7 +74,7 @@ void ParseRequestChunkProcessor::parseChunk() {
 }
 
 void ParseRequestChunkProcessor::printParseBodyResult() {
-  std::cout << "========Body=========\n";
-  std::cout << chunk_ << "$" << std::endl;
-  std::cout << "=====================\n";
+  client_.print(Log::debug, "========Body=========");
+  client_.print(Log::debug, chunk_ + "$");
+  client_.print(Log::debug, "=====================");
 }

--- a/src/processor/ParseRequestHeadProcessor.cpp
+++ b/src/processor/ParseRequestHeadProcessor.cpp
@@ -141,7 +141,7 @@ bool ParseRequestHeadProcessor::isChunk() {
 }
 
 void ParseRequestHeadProcessor::printParseHeadResult() {
-  client_.print(Log::debug, "ParseResult");
+  client_.print(Log::debug, " ParseResult");
   client_.print(Log::debug, "  method: " + request_.getMethod() + "$");
   client_.print(Log::debug, "  uri: " + request_.getUri() + "$");
   client_.print(Log::debug, "  version: " + request_.getVersion() + "$");

--- a/src/processor/ParseRequestHeadProcessor.cpp
+++ b/src/processor/ParseRequestHeadProcessor.cpp
@@ -41,11 +41,11 @@ ProcessResult ParseRequestHeadProcessor::process() {
           new ParseRequestBodyProcessor(client_));
     }
   } catch (std::length_error& e) {
-    std::cout << "Error: " << e.what() << std::endl;
+    client_.print(Log::debug, e.what());
     client_.setResponseStatusCode(402);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   } catch (std::exception& e) {
-    std::cout << "Error: " << e.what() << std::endl;
+    client_.print(Log::debug, e.what());
     client_.setResponseStatusCode(401);
     return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
   }
@@ -139,14 +139,13 @@ bool ParseRequestHeadProcessor::isChunk() {
 }
 
 void ParseRequestHeadProcessor::printParseHeadResult() {
-  std::cout << "=====ParseResult=====\n";
-  std::cout << "method: " << request_.getMethod() << "$" << std::endl;
-  std::cout << "uri: " << request_.getUri() << "$" << std::endl;
-  std::cout << "version: " << request_.getVersion() << "$" << std::endl;
+  client_.print(Log::debug, "ParseResult");
+  client_.print(Log::debug, "  method: " + request_.getMethod() + "$");
+  client_.print(Log::debug, "  uri: " + request_.getUri() + "$");
+  client_.print(Log::debug, "  version: " + request_.getVersion() + "$");
   std::map<std::string, std::string>::const_iterator iter;
   for (iter = request_.getHeaders().begin();
        iter != request_.getHeaders().end(); iter++) {
-    std::cout << iter->first << ": " << iter->second << "$" << std::endl;
+    client_.print(Log::debug, "  " + iter->first + ": " + iter->second + "$");
   }
-  std::cout << "=====================\n";
 }

--- a/src/processor/ParseRequestHeadProcessor.cpp
+++ b/src/processor/ParseRequestHeadProcessor.cpp
@@ -10,7 +10,9 @@
 #include "StringBuffer.hpp"
 
 ParseRequestHeadProcessor::ParseRequestHeadProcessor(IClient& client)
-    : readStatus_(START_LINE), client_(client), request_(client.getRequest()) {}
+    : readStatus_(START_LINE), client_(client), request_(client.getRequest()) {
+  client_.print(Log::info, " ParseRequestHeadProcessor");
+}
 
 ProcessResult ParseRequestHeadProcessor::process() {
   try {

--- a/src/processor/ProvideFileProcessor.cpp
+++ b/src/processor/ProvideFileProcessor.cpp
@@ -12,7 +12,9 @@ ProvideFileProcessor::ProvideFileProcessor(IClient& client,
       fileSize_(0),
       totalReadSize_(0),
       processReadFile_(false),
-      file_() {}
+      file_() {
+  client_.print(Log::info, " ProvideFileProcessor");
+}
 
 ProvideFileProcessor::~ProvideFileProcessor() {
   if (file_.is_open()) {

--- a/src/processor/RedirectionProcessor.cpp
+++ b/src/processor/RedirectionProcessor.cpp
@@ -2,7 +2,9 @@
 
 #include "WaitProcessor.hpp"
 
-RedirectionProcessor::RedirectionProcessor(IClient& client) : client_(client) {}
+RedirectionProcessor::RedirectionProcessor(IClient& client) : client_(client) {
+  client_.print(Log::info, " RedirectionProcessor");
+}
 
 ProcessResult RedirectionProcessor::process() {
   int status = client_.getLocationConfig()->getRedirectionStatusCode();

--- a/src/processor/SelectMethodProcessor.cpp
+++ b/src/processor/SelectMethodProcessor.cpp
@@ -11,7 +11,9 @@
 #include "RedirectionProcessor.hpp"
 
 SelectMethodProcessor::SelectMethodProcessor(IClient& client)
-    : client_(client) {}
+    : client_(client) {
+  client_.print(Log::info, " SelectMethodProcessor");
+}
 
 static bool cgiChecker(IClient& client_) {
   FilePath extension = FilePath::getExtension(client_.getRequest().getUri());

--- a/src/util/Log.cpp
+++ b/src/util/Log.cpp
@@ -1,0 +1,8 @@
+#include "Log.hpp"
+
+Log::Log(const char *color, int level) : color_(color), level_(level) {}
+
+Log Log::debug(LOG_WHITE, LOG_DEBUG);
+Log Log::info(LOG_GREEN, LOG_INFO);
+Log Log::warn(LOG_YELLOW, LOG_WARN);
+Log Log::error(LOG_RED, LOG_ERROR);

--- a/src/util/Log.hpp
+++ b/src/util/Log.hpp
@@ -9,7 +9,7 @@
 #define LOG_ERROR 1
 
 #ifndef LOG_LEVEL
-#define LOG_LEVEL LOG_DEBUG
+#define LOG_LEVEL LOG_INFO
 #endif
 
 #define NL "\n"

--- a/src/util/Log.hpp
+++ b/src/util/Log.hpp
@@ -1,0 +1,44 @@
+#ifndef Log_HPP_
+#define Log_HPP_
+
+#include <iostream>
+
+#define LOG_DEBUG 4
+#define LOG_INFO 3
+#define LOG_WARN 2
+#define LOG_ERROR 1
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL LOG_DEBUG
+#endif
+
+#define NL "\n"
+#define LOG_RED "\033[31m"
+#define LOG_GREEN "\033[32m"
+#define LOG_YELLOW "\033[33m"
+#define LOG_BLUE "\033[34m"
+#define LOG_WHITE "\033[37m"
+#define LOG_COLOR_RESET "\033[0m"
+
+class Log : public std::ostream {
+ public:
+  static Log debug;
+  static Log info;
+  static Log warn;
+  static Log error;
+
+  template <typename T>
+  Log& operator<<(const T& rhs) {
+    if (level_ <= LOG_LEVEL) {
+      std::cout << color_ << rhs << LOG_COLOR_RESET;
+    }
+    return *this;
+  }
+
+ private:
+  Log(const char* color, int level);
+  const char* color_;
+  int level_;
+};
+
+#endif


### PR DESCRIPTION
컴파일 시에 로그레벨에 따라 로그를 남기도록 수정정했습니다.
`ERROR`, `WARN`, `INFO`, `DEBUG` 네 단계가 있으며 각 로그의 색상을 다르게 출력합니다.
전체적으로 `<소켓번호>: <내용>` 형식으로 출력하도록 수정했씁니다.

---
출력 레벨 제어 방법

- `make`로 컴파일 할 경우 `INFO`단계로 설정되어 `DEBUG`를 제외한 모든 단계의 로그를 출력합니다.
.<img width="253" alt="image" src="https://github.com/42seoulWebserv/irc/assets/25172705/e6eda20e-f017-482d-962b-75e69df40965">

- `make debug`로 컴파일 할 경우 `DEBUG`로 설정되어 모든 단계의 로그를 출력합니다.
.<img width="261" alt="image" src="https://github.com/42seoulWebserv/irc/assets/25172705/07825ccc-c7b7-4467-abd5-2d4fff8f3116">

- 필요하다면 `LOG_LEVEL` 상수 값을 따로 지정하여 컴파일하고 원하는 로그 레벨을 출력할 수 있습니다.