### PR TITLE
Fix/cgi behaviour

### DIFF
--- a/html/api/cart.py
+++ b/html/api/cart.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import json
+import fcntl
+import random
+
+id = None
+sessionFilePath = 'sessions'
+
+def getSessionId():
+    global id
+    if id is not None:
+        return id
+    id = ''.join(random.sample('abcdefghijklmnopqrstuvwxyz0123456789', 8))
+    if 'HTTP_COOKIE' not in os.environ:
+        return id
+    cookies = os.environ['HTTP_COOKIE'].split(';')
+    for cookie in cookies:
+        if cookie.startswith('session='):
+            id = cookie[8:]
+            return id
+    return id
+
+def getSesseionData():
+    sessionId = getSessionId()
+    if not os.path.exists(sessionFilePath):
+        open(sessionFilePath, 'w').close()
+    with open(sessionFilePath, 'r+') as file:
+        fcntl.flock(file.fileno(), fcntl.LOCK_EX)
+        content = file.read()
+        if content == '':
+            sessions = {}
+        else:
+            sessions = json.loads(content)
+        fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+        if sessionId not in sessions:
+            return []
+        return sessions[sessionId]
+
+def setSessionData(data):
+    sessionId = getSessionId()
+    if not os.path.exists(sessionFilePath):
+        open(sessionFilePath, 'w').close()
+    with open('sessions', 'r+') as file:
+        fcntl.flock(file.fileno(), fcntl.LOCK_EX)
+        content = file.read()
+        if content == '':
+            sessions = {}
+        else:
+            sessions = json.loads(content)
+        sessions[sessionId] = data
+        file.seek(0)
+        file.write(json.dumps(sessions))
+        file.truncate()
+        fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+
+def writeResonse(status, body):
+    sys.stdout.write("Status: %d\r\n" % status)
+    sys.stdout.write("Content-Length: %d\r\n" % len(body))
+    if 'HTTP_ORIGIN' not in os.environ:
+        sys.stdout.write("Set-Cookie: session=%s\r\n" % getSessionId())
+    sys.stdout.write("Content-Type: application/json\r\n\r\n")
+    sys.stdout.write(body)
+
+if 'REQUEST_METHOD' not in os.environ:
+    sys.exit(1)
+method = os.environ['REQUEST_METHOD']
+
+if 'CONTENT_LENGTH' not in os.environ:
+    sys.exit(1)
+bodyLen = int(os.environ["CONTENT_LENGTH"])
+body = sys.stdin.read(bodyLen)
+
+
+if method == 'GET':
+    goods = getSesseionData()
+    writeResonse(200, json.dumps(goods))
+
+elif method == 'POST':
+    goods = getSesseionData()
+    goods.append(body)
+    setSessionData(goods)
+    writeResonse(201, '')
+
+elif method == 'PUT':
+    goods = getSesseionData()
+    if body in goods:
+        writeResonse(200, '')
+    else:
+        goods.append(body)
+        setSessionData(goods)
+        writeResonse(201, '')
+
+elif method == 'DELETE':
+    goods = getSesseionData()
+    if body in goods:
+        goods.remove(body)
+        setSessionData(goods)
+        writeResonse(200, '')
+    else:
+        writeResonse(204, '')
+
+else:
+    sys.exit(1)
+

--- a/html/api/echo.sh
+++ b/html/api/echo.sh
@@ -1,0 +1,8 @@
+echo "Status: 200\r"
+echo "Content-Length: $CONTENT_LENGTH\r"
+echo "Content-Type: text/plain\r\n\r"
+
+# Read the body if size not 0
+if [ $CONTENT_LENGTH -gt 0 ]; then
+    head -c $CONTENT_LENGTH
+fi

--- a/src/ICgi.hpp
+++ b/src/ICgi.hpp
@@ -11,7 +11,6 @@ class ICgi {
  public:
   virtual ~ICgi(){};
 
-  virtual void setFd(int &fd) = 0;
   virtual int getFd() = 0;
   virtual StringBuffer &getRecvBuffer() = 0;
   virtual DataStream &getWriteBuffer() = 0;

--- a/src/ICgi.hpp
+++ b/src/ICgi.hpp
@@ -14,7 +14,6 @@ class ICgi {
   virtual void setFd(int &fd) = 0;
   virtual int getFd() = 0;
   virtual StringBuffer &getRecvBuffer() = 0;
-  virtual void end() = 0;
   virtual DataStream &getWriteBuffer() = 0;
   virtual void print(Log &logger, const std::string &msg) = 0;
 };

--- a/src/controller/CgiEventController.cpp
+++ b/src/controller/CgiEventController.cpp
@@ -14,7 +14,7 @@
 
 CgiEventController::CgiEventController(
     IClient& client, IObserver<CgiEventController::Event>* observer)
-    : EventController(new CgiInProcessor(*this, client)),
+    : EventController(NULL),
       client_(client),
       cancel_(false),
       pid_(0),
@@ -80,6 +80,7 @@ void CgiEventController::init() {
   setFd(fd[0]);
   Multiplexer::getInstance().addReadEvent(fd_, this);
   Multiplexer::getInstance().addWriteEvent(fd_, this);
+  setProcessor(new CgiInProcessor(*this, client_));
   if (loopProcess()) {
     throw std::runtime_error("process error");
   }

--- a/src/controller/CgiEventController.cpp
+++ b/src/controller/CgiEventController.cpp
@@ -18,8 +18,7 @@ CgiEventController::CgiEventController(
       client_(client),
       cancel_(false),
       pid_(0),
-      observer_(observer),
-      end_(false) {}
+      observer_(observer) {}
 
 CgiEventController::~CgiEventController() {
   int err;
@@ -147,8 +146,6 @@ void CgiEventController::setFd(int& fd) { fd_ = fd; }
 int CgiEventController::getFd() { return fd_; }
 
 StringBuffer& CgiEventController::getRecvBuffer() { return recvBuffer_; }
-
-void CgiEventController::end() { end_ = true; }
 
 DataStream& CgiEventController::getWriteBuffer() { return writeBuffer_; }
 

--- a/src/controller/CgiEventController.cpp
+++ b/src/controller/CgiEventController.cpp
@@ -58,21 +58,22 @@ void CgiEventController::init() {
     char* program = new char[root.size() + 1];
     std::strcpy(program, root.c_str());
 
-    char* const argv[] = {program, NULL};
-    std::vector<char*> envp_vec;
-    envp_vec.push_back(
-        strdup(("REQUEST_METHOD=" + client_.getRequest().getMethod()).c_str()));
+    std::vector<char*> argvList;
+    argvList.push_back(program);
+    argvList.push_back(strdup(client_.getRequestResourcePath().c_str()));
+    argvList.push_back(NULL);
 
-    envp_vec.push_back(strdup(
-        ("SERVER_PROTOCOL=" + client_.getRequest().getVersion()).c_str()));
-    envp_vec.push_back(
-        strdup(("PATH_INFO=" + client_.getRequest().getUri()).c_str()));
+    const Request& req = client_.getRequest();
+    std::vector<char*> envpList;
+    envpList.push_back(strdup(("REQUEST_METHOD=" + req.getMethod()).c_str()));
+    envpList.push_back(strdup(("SERVER_PROTOCOL=" + req.getVersion()).c_str()));
+    envpList.push_back(strdup(("PATH_INFO=" + req.getUri()).c_str()));
     std::stringstream ss;
-    ss << client_.getRequest().getBody().size();
-    envp_vec.push_back(strdup(("CONTENT_LENGTH=" + ss.str()).c_str()));
-    envp_vec.push_back(NULL);
-    char* const* envp = &envp_vec[0];
-    execve(program, argv, envp);
+    ss << req.getBody().size();
+    envpList.push_back(strdup(("CONTENT_LENGTH=" + ss.str()).c_str()));
+    envpList.push_back(NULL);
+
+    execve(program, argvList.data(), envpList.data());
     perror("execve");
     _exit(1);
   }

--- a/src/controller/CgiEventController.cpp
+++ b/src/controller/CgiEventController.cpp
@@ -71,6 +71,10 @@ void CgiEventController::init() {
     std::stringstream ss;
     ss << req.getBody().size();
     envpList.push_back(strdup(("CONTENT_LENGTH=" + ss.str()).c_str()));
+    if (req.hasHeader("Cookie")) {
+      envpList.push_back(
+          strdup(("HTTP_COOKIE=" + req.getHeader("Cookie")).c_str()));
+    }
     envpList.push_back(NULL);
 
     execve(program, argvList.data(), envpList.data());

--- a/src/controller/CgiEventController.hpp
+++ b/src/controller/CgiEventController.hpp
@@ -30,7 +30,6 @@ class CgiEventController : public EventController,
   void setFd(int &fd);
   int getFd();
   StringBuffer &getRecvBuffer();
-  void end();
   DataStream &getWriteBuffer();
   void clear(bool error);
   void print(Log &logger, const std::string &msg);
@@ -43,7 +42,6 @@ class CgiEventController : public EventController,
   pid_t pid_;
   IObserver<CgiEventController::Event> *observer_;
   StringBuffer recvBuffer_;
-  bool end_;
   DataStream writeBuffer_;
 };
 

--- a/src/controller/EventController.cpp
+++ b/src/controller/EventController.cpp
@@ -1,11 +1,17 @@
 #include "EventController.hpp"
 
 EventController::EventController(IProcessor *processor)
-    : processor_(processor) {}
+    : deprecated_(false), processor_(processor) {}
 
 EventController::~EventController() { delete processor_; }
 
 int EventController::getFd() const { return fd_; }
+
+bool EventController::isDeprecated() const { return deprecated_; }
+
+void EventController::setDeprecated(bool deprecated) {
+  deprecated_ = deprecated;
+}
 
 bool EventController::loopProcess() {
   ProcessResult processResult = nextProcessor();

--- a/src/controller/EventController.cpp
+++ b/src/controller/EventController.cpp
@@ -25,6 +25,12 @@ void EventController::reserveDeleteSelf() {
   Multiplexer::getInstance().addDeleteController(this);
 }
 
+void EventController::setProcessor(IProcessor *processor) {
+  processor_ = processor;
+}
+
+IProcessor *EventController::getProcessor() const { return processor_; }
+
 ProcessResult EventController::nextProcessor() {
   if (processor_ == NULL) {
     return ProcessResult().setError(true);

--- a/src/controller/EventController.hpp
+++ b/src/controller/EventController.hpp
@@ -17,9 +17,12 @@ class EventController {
   virtual void handleEvent(const Multiplexer::Event &event) = 0;
 
   int getFd() const;
+  bool isDeprecated() const;
+  void setDeprecated(bool deprecated);
 
  protected:
   int fd_;
+  bool deprecated_;
   bool loopProcess();
   void reserveDeleteSelf();
 

--- a/src/controller/EventController.hpp
+++ b/src/controller/EventController.hpp
@@ -25,6 +25,8 @@ class EventController {
   bool deprecated_;
   bool loopProcess();
   void reserveDeleteSelf();
+  void setProcessor(IProcessor *processor);
+  IProcessor *getProcessor() const;
 
  private:
   IProcessor *processor_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,9 @@ int run(RootConfig &config) {
   while (1) {
     std::vector<Multiplexer::Event> events = Multiplexer.wait(5);
     for (size_t i = 0; i < events.size(); i++) {
-      events[i].controller->handleEvent(events[i]);
+      if (events[i].controller->isDeprecated() == false) {
+        events[i].controller->handleEvent(events[i]);
+      }
     }
     Multiplexer::getInstance().deleteAddedControllers();
   }

--- a/src/multiplexer/mac/Multiplexer.cpp
+++ b/src/multiplexer/mac/Multiplexer.cpp
@@ -78,6 +78,10 @@ std::vector<Multiplexer::Event> Multiplexer::wait(int size) {
 }
 
 void Multiplexer::addDeleteController(EventController* controller) {
+  if (controller == NULL) {
+    return;
+  }
+  controller->setDeprecated(true);
   removeReadEvent(controller->getFd(), controller);
   removeWriteEvent(controller->getFd(), controller);
   removeTimeoutEvent(controller->getFd(), controller);

--- a/src/processor/CgiOutProcessor.cpp
+++ b/src/processor/CgiOutProcessor.cpp
@@ -24,7 +24,6 @@ ProcessResult CgiOutProcessor::process() {
   for (it = headers.begin(); it != headers.end(); it++) {
     client_.setResponseHeader(it->first, it->second);
   }
-  cgi_.end();
   return ProcessResult().setNextProcessor(new WaitProcessor());
 }
 

--- a/src/processor/CgiProcessor.cpp
+++ b/src/processor/CgiProcessor.cpp
@@ -34,6 +34,11 @@ ProcessResult CgiProcessor::process() {
   if (cgi_) {
     return ProcessResult();
   }
+  FilePath path = client_.getRequestResourcePath();
+  if (path.isFile() == false || path.isAccessible(FilePath::READ) == false) {
+    client_.setResponseStatusCode(404);
+    return ProcessResult().setNextProcessor(new ErrorPageProcessor(client_));
+  }
   cgi_ = CgiEventController::addEventController(client_, this);
   if (cgi_ == NULL) {
     client_.setResponseStatusCode(500);

--- a/src/util/DataStream.cpp
+++ b/src/util/DataStream.cpp
@@ -20,6 +20,9 @@ DataStream::Chunk::Chunk(int seq, int size)
 DataStream::Chunk::~Chunk() { delete[] buffer_; }
 
 int DataStream::readStr(const std::string &str) {
+  if (str.size() == 0) {
+    return 0;
+  }
   Chunk *chunk = new Chunk(seq_++, str.size());
   std::memcpy(chunk->buffer_, str.c_str(), str.size());
   totalRead_ += str.size();


### PR DESCRIPTION
- `cgi`를 실행할때 스크립트를 첫 번쨰 인자로 넘겨 실행할 수 있도록 변경했습니다.
  - 만약 전달할 `script 파일`이 존재하지 않으면 `404`에러 페이지를 제공합니다.
  - 추가로 `cookie`헤더를 cgi 프로그램에게 전달할 수 있도록 수정했습니다.
- 사용하지 않는 변수, `CgiEventController::end` 를 정리했습니다.
- `DataStream::readStr`에서 문자열의 `size` 가 `0`일때의 버그를 수정했습니다.
- `EventController`에 `deprecated` 플래그 변수를 추가했습니다.
  - 이를 통해 더 이상 실행하지 않아도 되는 컨트롤러를 실행하던 버그를 수정했습니다.