### PR TITLE
feat: content-type for jpg

### DIFF
--- a/src/processor/ProvideFileProcessor.cpp
+++ b/src/processor/ProvideFileProcessor.cpp
@@ -45,6 +45,9 @@ ProcessResult ProvideFileProcessor::process() {
   fileSize_ = path_.getFileSize();
   std::stringstream ss;
   ss << path_.getFileSize();
+  if (FilePath::getExtension(client_.getRequestResourcePath()) == "jpg") {
+    client_.setResponseHeader("Content-Type", "image/jpeg");
+  }
   client_.setResponseHeader("Content-Length", ss.str());
   client_.getDataStream().readStr(response.toString());
   if (fileSize_ == 0) {


### PR DESCRIPTION
브라우저에서도 저희 웹서버가 잘 동작하는지 보여주는 시나리오에서 이미지파일을 `GET` 요청할때 여전히 응답 헤더는 `Content-Type: text/html`이므로 브라우저에서 이미지를 제대로 보여주지 못하는 문제가 있습니다.

저희 서버는 mime 맵을 포함하지 않으므로 특별케이스로, jpg 확장자의 파일에 대해 `Content-Type: image/jpeg`로 설정할 것을 제안합니다.