### PR TITLE
fix: keep-alive bug fix

### DIFF
--- a/src/processor/ProvideFileProcessor.cpp
+++ b/src/processor/ProvideFileProcessor.cpp
@@ -65,21 +65,19 @@ ProcessResult ProvideFileProcessor::process() {
 
 ProcessResult ProvideFileProcessor::processReadFile() {
   int size = client_.getDataStream().readFile(file_);
-  totalReadSize_ += size;
-
   if (size == DELAYED_FILE_READ) {
     return ProcessResult();
   }
   if (size == -1) {
     return ProcessResult().setError(true);
   }
+  totalReadSize_ += size;
+
   if (size != 0) {
     return ProcessResult();
   }
 
-  const int responseHeaderSize = client_.getResponse().toString().size();
-  const int bodySize = totalReadSize_ - responseHeaderSize;
-  if (bodySize != fileSize_) {
+  if (totalReadSize_ != fileSize_) {
     return ProcessResult().setError(true);
   }
 


### PR DESCRIPTION
다음 오류를 해결합니다.
- #91 

`ProvideFileProcessor`에서 실제 읽은 파일의 크기와 전달할 파일의 크키가 다르면 에러를 발생시키는 로직이 있었고 에러 상황으로 판단되어 keep-alive를 유지하지 못하고 있던 오류였습니다. 실제 전달하는 파일의 크기는 정상이었으나 파일의 크기를 계산하는 로직에 문제가 있어 해당 내용을 수정하였습니다.