### PR TITLE
fix: mismatch status code

### DIFF
--- a/src/controller/ClientEventController.cpp
+++ b/src/controller/ClientEventController.cpp
@@ -137,7 +137,9 @@ const LocationConfig *ClientEventController::getLocationConfig() {
   if (config_ == NULL) {
     ServerConfig *serverConfig = selectServerConfig(request_, serverConfigs_);
     if (serverConfig == NULL) {
-      response_.setStatusCode(400);
+      if (response_.getStatusCode() == 100) {
+        response_.setStatusCode(400);
+      }
       return NULL;
     }
     config_ = selectLocationConfig(serverConfig->getLocationConfigs(),


### PR DESCRIPTION
`curl -X HEAD localhost:8080 -v`요청을 보낼시 상태코드는 400, 바디내용은 401에 해당하는 오류 내용을 반환하던 오류를 수정합니다.
