### PR TITLE
chore: fix wrong debug message

### DIFF
--- a/src/processor/ProvideFileProcessor.cpp
+++ b/src/processor/ProvideFileProcessor.cpp
@@ -27,9 +27,9 @@ ProcessResult ProvideFileProcessor::process() {
     return processReadFile();
   }
   if (path_.isFile() == false || path_.isAccessible(FilePath::READ) == false) {
+    client_.setResponseStatusCode(404);
     ErrorPageProcessor* errorPage = new ErrorPageProcessor(client_);
     errorPage->forceProvideDefaultPage();
-    client_.setResponseStatusCode(404);
     return ProcessResult().setNextProcessor(errorPage);
   }
   const Response& response = client_.getResponse();


### PR DESCRIPTION
ProvideFileProcessor에서 파일을 찾지 못할 경우 404를 상태코드의 에러페이지를 만드는데 콘솔에는 200 에러페이지를 만들었다고 표시되는 로깅 에러를 수정했습니다.
